### PR TITLE
Waves started from debug menu now can and will hurt you

### DIFF
--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -570,7 +570,6 @@ function Battle:onStateChange(old,new)
                 if Utils.containsValue(enemy.waves, self.state_reason[1]) then
                     enemy.selected_wave = self.state_reason[1]
                     enemy_found = true
-                    break
                 end
             end
             if not enemy_found then

--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -566,6 +566,9 @@ function Battle:onStateChange(old,new)
         self:setWaves(self.encounter:getNextWaves())
         if self.state_reason then
             self:setWaves(self.state_reason)
+            for i,enemy in ipairs(self.enemies) do
+                enemy.selected_wave = self.state_reason[1]
+            end
         end
 
         if self.arena then

--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -563,12 +563,21 @@ function Battle:onStateChange(old,new)
         self.current_selecting = 0
         self.battle_ui:clearEncounterText()
 
-        self:setWaves(self.encounter:getNextWaves())
         if self.state_reason then
             self:setWaves(self.state_reason)
+            local enemy_found = false
             for i,enemy in ipairs(self.enemies) do
-                enemy.selected_wave = self.state_reason[1]
+                if Utils.containsValue(enemy.waves, self.state_reason[1]) then
+                    enemy.selected_wave = self.state_reason[1]
+                    enemy_found = true
+                    break
+                end
             end
+            if not enemy_found then
+                self.enemies[love.math.random(1, #self.enemies)].selected_wave = self.state_reason[1]
+            end
+        else
+            self:setWaves(self.encounter:getNextWaves())
         end
 
         if self.arena then


### PR DESCRIPTION
When starting a wave through the debug menu, the enemies' `selected_wave` variable doesn't get set to the new wave and instead get set randomly like it does normally, so when the engine wants to calculate the damage, it got no enemies to use and returns nothing