### PR TITLE
Add Event interaction buffer

### DIFF
--- a/src/engine/game/world/event.lua
+++ b/src/engine/game/world/event.lua
@@ -29,6 +29,9 @@ function Event:init(x, y, w, h)
 
     -- Sprite object, gets set by setSprite()
     self.sprite = nil
+
+    -- Duration that the player cannot interact with events for on finishing interaction (in frames, at 30fps)
+    self.buffer = 5
 end
 
 --[[ OPTIONAL FUNCTIONS

--- a/src/engine/game/world/events/cybertrashcan.lua
+++ b/src/engine/game/world/events/cybertrashcan.lua
@@ -105,6 +105,8 @@ function CyberTrashCan:onInteract(player, dir)
             Game:setFlag(self.set_flag, (self.set_value == nil and true) or self.set_value)
         end
     end
+
+    return true
 end
 
 return CyberTrashCan

--- a/src/engine/game/world/events/forcefield.lua
+++ b/src/engine/game/world/events/forcefield.lua
@@ -79,6 +79,8 @@ end
 
 function Forcefield:onInteract(player, dir)
     Game.world:showText("* (It appears to be some kind of forcefield.)")
+
+    return true
 end
 
 function Forcefield:update()

--- a/src/engine/game/world/events/npc.lua
+++ b/src/engine/game/world/events/npc.lua
@@ -36,6 +36,8 @@ function NPC:init(actor, x, y, properties)
     self.set_value = properties["setvalue"]
 
     self.interact_count = 0
+
+    self.buffer = 5
 end
 
 function NPC:onInteract(player, dir)

--- a/src/engine/game/world/events/treasurechest.lua
+++ b/src/engine/game/world/events/treasurechest.lua
@@ -91,6 +91,8 @@ function TreasureChest:onInteract(player, dir)
             Game:setFlag(self.set_flag, (self.set_value == nil and true) or self.set_value)
         end
     end
+
+    return true
 end
 
 return TreasureChest

--- a/src/engine/game/world/events/warpdoor.lua
+++ b/src/engine/game/world/events/warpdoor.lua
@@ -87,6 +87,8 @@ function WarpDoor:onInteract(chara, facing)
             end
         end)
     end
+
+    return true
 end
 
 function WarpDoor:updateOpen()

--- a/src/engine/game/world/player.lua
+++ b/src/engine/game/world/player.lua
@@ -39,6 +39,8 @@ function Player:init(chara, x, y)
     self.history_time = 0
     self.history = {}
 
+    self.interact_buffer = 0
+
     self.battle_canvas = love.graphics.newCanvas(320, 240)
     self.battle_alpha = 0
 
@@ -104,6 +106,10 @@ function Player:setActor(actor)
 end
 
 function Player:interact()
+    if self.interact_buffer > 0 then
+        return true
+    end
+
     local col = self.interact_collider[self.facing]
 
     local interactables = {}
@@ -116,6 +122,7 @@ function Player:interact()
     table.sort(interactables, function(a,b) return a.dist < b.dist end)
     for _,v in ipairs(interactables) do
         if v.obj:onInteract(self, self.facing) then
+            self.interact_buffer = v.obj.buffer or 0
             return true
         end
     end
@@ -339,6 +346,10 @@ function Player:update()
     self.state_manager:update()
 
     self:updateHistory()
+
+    if not Game.world.cutscene and not Game.world.menu then
+        self.interact_buffer = self.interact_buffer - DTMULT
+    end
 
     self.world.in_battle_area = false
     for _,area in ipairs(self.world.map.battle_areas) do


### PR DESCRIPTION
In DELTARUNE, there is a small buffer period after finishing an interaction where the player cannot interact with that object (and theoretically any other objects), this adds that buffer into Kristal.