### PR TITLE
Added Character:alert() (and variations)

### DIFF
--- a/src/engine/game/battle/battlecutscene.lua
+++ b/src/engine/game/battle/battlecutscene.lua
@@ -176,6 +176,14 @@ function BattleCutscene:shakeCamera(x, y, friction)
     return cameraShakeCheck
 end
 
+function BattleCutscene:alert(chara, ...)
+    if type(chara) == "string" then
+        chara = self:getCharacter(chara)
+    end
+    local function waitForAlertRemoval() return chara.alert_icon == nil or chara.alert_timer == 0 end
+    return chara:alert(...), waitForAlertRemoval
+end
+
 function BattleCutscene:fadeOut(speed, options)
     options = options or {}
 

--- a/src/engine/game/battle/battler.lua
+++ b/src/engine/game/battle/battler.lua
@@ -25,6 +25,10 @@ function Battler:init(x, y, width, height)
 
     -- Speech bubble style - defaults to "round" or "cyber", depending on chapter
     self.dialogue_bubble = nil
+
+    self.alert_timer = 0
+    self.alert_icon = nil
+    self.alert_callback = nil
 end
 
 function Battler:setActor(actor, use_overlay)
@@ -63,6 +67,24 @@ end
 function Battler:flash(sprite, offset_x, offset_y, layer)
     local sprite_to_use = sprite or self.sprite
     return sprite_to_use:flash(offset_x, offset_y, layer)
+end
+
+function Battler:alert(callback, duration, offset_x, offset_y, play_sound, sprite, layer)
+    if play_sound == nil then play_sound = true end
+    if play_sound then
+        Assets.stopAndPlaySound("alert")
+    end
+    local sprite_to_use = sprite or "effects/alert"
+    if offset_x == nil then offset_x = 0 end
+    if offset_y == nil then offset_y = 0 end
+    self.alert_timer = duration or 20
+    if self.alert_icon then self.alert_icon:remove() end
+    self.alert_icon = Sprite(sprite_to_use, (self.width/2)+offset_x, offset_y)
+    self.alert_icon:setOrigin(0.5, 1)
+    self.alert_icon.layer = layer or 100
+    self:addChild(self.alert_icon)
+    self.alert_callback = callback
+    return self.alert_icon
 end
 
 function Battler:sparkle(r, g, b)
@@ -171,6 +193,18 @@ function Battler:update()
         self.highlight.amount = 0
         self.flash_timer = 0
         self.last_highlighted = false
+    end
+
+    if self.alert_timer > 0 then
+        self.alert_timer = Utils.approach(self.alert_timer, 0, DTMULT)
+        if self.alert_timer == 0 then
+            self.alert_icon:remove()
+            self.alert_icon = nil
+            if self.alert_callback then
+                self.alert_callback()
+                self.alert_callback = nil
+            end
+        end
     end
 
     super.update(self)

--- a/src/engine/game/battle/battler.lua
+++ b/src/engine/game/battle/battler.lua
@@ -69,21 +69,19 @@ function Battler:flash(sprite, offset_x, offset_y, layer)
     return sprite_to_use:flash(offset_x, offset_y, layer)
 end
 
-function Battler:alert(callback, duration, offset_x, offset_y, play_sound, sprite, layer)
-    if play_sound == nil then play_sound = true end
-    if play_sound then
+function Battler:alert(duration, options)
+    options = options or {}
+    if options["play_sound"] == nil or options["play_sound"] then
         Assets.stopAndPlaySound("alert")
     end
-    local sprite_to_use = sprite or "effects/alert"
-    if offset_x == nil then offset_x = 0 end
-    if offset_y == nil then offset_y = 0 end
-    self.alert_timer = duration or 20
+    local sprite_to_use = options["sprite"] or "effects/alert"
+    self.alert_timer = duration and duration*30 or 20
     if self.alert_icon then self.alert_icon:remove() end
-    self.alert_icon = Sprite(sprite_to_use, (self.width/2)+offset_x, offset_y)
+    self.alert_icon = Sprite(sprite_to_use, (self.width/2)+(options["offset_x"] or 0), options["offset_y"] or 0)
     self.alert_icon:setOrigin(0.5, 1)
-    self.alert_icon.layer = layer or 100
+    self.alert_icon.layer = options["layer"] or 100
     self:addChild(self.alert_icon)
-    self.alert_callback = callback
+    self.alert_callback = options["callback"]
     return self.alert_icon
 end
 

--- a/src/engine/game/world/character.lua
+++ b/src/engine/game/world/character.lua
@@ -30,6 +30,10 @@ function Character:init(actor, x, y)
 
     self.spin_timer = 0
     self.spin_speed = 0
+
+    self.alert_timer = 0
+    self.alert_icon = nil
+    self.alert_callback = nil
 end
 
 function Character:getDebugInfo()
@@ -342,6 +346,24 @@ function Character:flash(sprite, offset_x, offset_y, layer)
     return sprite_to_use:flash(offset_x, offset_y, layer)
 end
 
+function Character:alert(callback, duration, offset_x, offset_y, play_sound, sprite, layer)
+    if play_sound == nil then play_sound = true end
+    if play_sound then
+        Assets.stopAndPlaySound("alert")
+    end
+    local sprite_to_use = sprite or "effects/alert"
+    if offset_x == nil then offset_x = 0 end
+    if offset_y == nil then offset_y = 0 end
+    self.alert_timer = duration or 20
+    if self.alert_icon then self.alert_icon:remove() end
+    self.alert_icon = Sprite(sprite_to_use, (self.width/2)+offset_x, offset_y)
+    self.alert_icon:setOrigin(0.5, 1)
+    self.alert_icon.layer = layer or 100
+    self:addChild(self.alert_icon)
+    self.alert_callback = callback
+    return self.alert_icon
+end
+
 function Character:setSprite(sprite)
     self.sprite:setSprite(sprite)
 end
@@ -607,6 +629,18 @@ function Character:update()
         end
     else
         self.spin_timer = 0
+    end
+
+    if self.alert_timer > 0 then
+        self.alert_timer = Utils.approach(self.alert_timer, 0, DTMULT)
+        if self.alert_timer == 0 then
+            self.alert_icon:remove()
+            self.alert_icon = nil
+            if self.alert_callback then
+                self.alert_callback()
+                self.alert_callback = nil
+            end
+        end
     end
 
     super.update(self)

--- a/src/engine/game/world/character.lua
+++ b/src/engine/game/world/character.lua
@@ -346,21 +346,19 @@ function Character:flash(sprite, offset_x, offset_y, layer)
     return sprite_to_use:flash(offset_x, offset_y, layer)
 end
 
-function Character:alert(callback, duration, offset_x, offset_y, play_sound, sprite, layer)
-    if play_sound == nil then play_sound = true end
-    if play_sound then
+function Character:alert(duration, options)
+    options = options or {}
+    if options["play_sound"] == nil or options["play_sound"] then
         Assets.stopAndPlaySound("alert")
     end
-    local sprite_to_use = sprite or "effects/alert"
-    if offset_x == nil then offset_x = 0 end
-    if offset_y == nil then offset_y = 0 end
-    self.alert_timer = duration or 20
+    local sprite_to_use = options["sprite"] or "effects/alert"
+    self.alert_timer = duration and duration*30 or 20
     if self.alert_icon then self.alert_icon:remove() end
-    self.alert_icon = Sprite(sprite_to_use, (self.width/2)+offset_x, offset_y)
+    self.alert_icon = Sprite(sprite_to_use, (self.width/2)+(options["offset_x"] or 0), options["offset_y"] or 0)
     self.alert_icon:setOrigin(0.5, 1)
-    self.alert_icon.layer = layer or 100
+    self.alert_icon.layer = options["layer"] or 100
     self:addChild(self.alert_icon)
-    self.alert_callback = callback
+    self.alert_callback = options["callback"]
     return self.alert_icon
 end
 

--- a/src/engine/game/world/chaserenemy.lua
+++ b/src/engine/game/world/chaserenemy.lua
@@ -225,11 +225,11 @@ function ChaserEnemy:update()
                     local sight = LineCollider(self.world, self.x, self.y, self.world.player.x, self.world.player.y)
                     if not self.world:checkCollision(sight, true) and not self.world:checkCollision(self.collider, true) then
                         self.path = nil
-                        self:alert(function()
+                        self:alert(nil, {callback=function()
                             self.chasing = true
                             self.noclip = false
                             self:setAnimation("chasing")
-                        end)
+                        end})
                         self:setAnimation("alerted")
                     end
                 end

--- a/src/engine/game/world/chaserenemy.lua
+++ b/src/engine/game/world/chaserenemy.lua
@@ -32,9 +32,6 @@ function ChaserEnemy:init(actor, x, y, properties)
     self.chase_dist = properties["chasedist"] or 200
     self.chasing = properties["chasing"] or false
 
-    self.alert_timer = 0
-    self.alert_icon = nil
-
     self.noclip = true
     self.enemy_collision = true
 
@@ -220,29 +217,19 @@ function ChaserEnemy:update()
             self:snapToPath()
         end
 
-        if self.alert_timer > 0 then
-            self.alert_timer = Utils.approach(self.alert_timer, 0, DTMULT)
-            if self.alert_timer == 0 then
-                self.alert_icon:remove()
-                self.alert_icon = nil
-                self.chasing = true
-                self.noclip = false
-                self:setAnimation("chasing")
-            end
-        elseif self.can_chase and not self.chasing then
+        if self.alert_timer == 0 and self.can_chase and not self.chasing then
             if self.world.player then
                 Object.startCache()
                 local in_radius = self.world.player:collidesWith(CircleCollider(self.world, self.x, self.y, self.chase_dist))
                 if in_radius then
                     local sight = LineCollider(self.world, self.x, self.y, self.world.player.x, self.world.player.y)
                     if not self.world:checkCollision(sight, true) and not self.world:checkCollision(self.collider, true) then
-                        Assets.stopAndPlaySound("alert")
                         self.path = nil
-                        self.alert_timer = 20
-                        self.alert_icon = Sprite("effects/alert", self.width/2)
-                        self.alert_icon:setOrigin(0.5, 1)
-                        self.alert_icon.layer = 100
-                        self:addChild(self.alert_icon)
+                        self:alert(function()
+                            self.chasing = true
+                            self.noclip = false
+                            self:setAnimation("chasing")
+                        end)
                         self:setAnimation("alerted")
                     end
                 end

--- a/src/engine/game/world/worldcutscene.lua
+++ b/src/engine/game/world/worldcutscene.lua
@@ -304,6 +304,14 @@ function WorldCutscene:shakeCamera(x, y, friction)
     return waitForCameraShake
 end
 
+function WorldCutscene:alert(chara, ...)
+    if type(chara) == "string" then
+        chara = self:getCharacter(chara)
+    end
+    local function waitForAlertRemoval() return chara.alert_icon == nil or chara.alert_timer == 0 end
+    return chara:alert(...), waitForAlertRemoval
+end
+
 function WorldCutscene:detachCamera()
     Game.world:setCameraAttached(false)
 end


### PR DESCRIPTION
Made the alert box thingy from ChaserEnemy something that can be easily used for Character and Battler. The alert box can be spawned using `Character:alert()`, `Battler:alert()` and the function with the same name for world and battle cutscenes

The arguments are `duration`, and options. The default value for duration is 20/30 and the options table can take the following arguments:
- `callback`: a function called after the alert has dissappear. Default to nothing
-  `offset_x`, `offset_y`: By how much the alert should be moved away from its spawning position. Defaults to 0
- `play_sound`: Should the alert sound effect plays? Default to true.
- `sprite`: The sprite that'll be used for the alert. Defaults to "effects/alert"
- `layer`: The layer on which the alert will appear *based on the character itself*. Defaults to 100

The functions themselves returns the sprite object that is the alert box. The cutscenes function returns the same thing plus a function that can be used with `cutscene:wait()`