### PR TITLE
Added Game.all_party

### DIFF
--- a/src/engine/game/common/data/partymember.lua
+++ b/src/engine/game/common/data/partymember.lua
@@ -137,6 +137,9 @@ function PartyMember:init()
         [19] = 50000,
         [20] = 99999
     }
+    
+    -- Sets all defined party members into a table
+    table.insert(Game.all_party, self)
 end
 
 -- Callbacks

--- a/src/engine/game/game.lua
+++ b/src/engine/game/game.lua
@@ -237,6 +237,8 @@ function Game:load(data, index, fade)
     self.shop = nil
 
     self.max_followers = Kristal.getModOption("maxFollowers") or 10
+    
+    self.all_party = {}
 
     self.light = false
 

--- a/src/engine/game/world/events/savepoint.lua
+++ b/src/engine/game/world/events/savepoint.lua
@@ -46,7 +46,7 @@ function Savepoint:onTextEnd()
     if not self.world then return end
 
     if self.heals then
-        for _,party in ipairs(Game.party) do
+        for _,party in ipairs(Game.all_party) do
             party:heal(math.huge, false)
         end
     end


### PR DESCRIPTION
This returns all defined party members, even ones who are not in your current party. Save points will heal all defined party member, just like in Deltarune.