### PR TITLE
new Enemy:hurt() argument to make the Damage Status Message opcional

### DIFF
--- a/src/engine/game/battle/enemybattler.lua
+++ b/src/engine/game/battle/enemybattler.lua
@@ -453,7 +453,7 @@ function EnemyBattler:hurt(amount, battler, on_defeat, color, show_status)
     end
 
     self.health = self.health - amount
-    if show_status then
+    if show_status ~= false then
         self:statusMessage("damage", amount, color or (battler and {battler.chara:getDamageColor()}))
     end
 

--- a/src/engine/game/battle/enemybattler.lua
+++ b/src/engine/game/battle/enemybattler.lua
@@ -442,16 +442,20 @@ function EnemyBattler:isXActionShort(battler)
     return false
 end
 
-function EnemyBattler:hurt(amount, battler, on_defeat, color)
+function EnemyBattler:hurt(amount, battler, on_defeat, color, show_status)
     if amount == 0 or (amount < 0 and Game:getConfig("damageUnderflowFix")) then
-        self:statusMessage("msg", "miss", color or (battler and {battler.chara:getDamageColor()}))
+        if show_status then
+            self:statusMessage("msg", "miss", color or (battler and {battler.chara:getDamageColor()}))
+        end
 
         self:onDodge(battler)
         return
     end
 
     self.health = self.health - amount
-    self:statusMessage("damage", amount, color or (battler and {battler.chara:getDamageColor()}))
+    if show_status then
+        self:statusMessage("damage", amount, color or (battler and {battler.chara:getDamageColor()}))
+    end
 
     if amount > 0 then
         self.hurt_timer = 1

--- a/src/engine/game/battle/enemybattler.lua
+++ b/src/engine/game/battle/enemybattler.lua
@@ -444,7 +444,7 @@ end
 
 function EnemyBattler:hurt(amount, battler, on_defeat, color, show_status)
     if amount == 0 or (amount < 0 and Game:getConfig("damageUnderflowFix")) then
-        if show_status then
+        if show_status ~= false then
             self:statusMessage("msg", "miss", color or (battler and {battler.chara:getDamageColor()}))
         end
 


### PR DESCRIPTION
This can be useful for a bunch of things:

1) Maybe you just don't want the status message.
2) You want to call this function but manually show a status message that says something else, without there being two status messages.

That's all

Oh also I know you could just "change the defaultfunction in a specific enemy" but maybe you need this for... all enemies.
Like, if you're making a spell that requires this
Or an act or something
Idk