### PR TITLE
Accuracy fix for PartyBattler pushback animation.

### DIFF
--- a/src/engine/game/battle/partybattler.lua
+++ b/src/engine/game/battle/partybattler.lua
@@ -16,9 +16,9 @@ function PartyBattler:init(chara, x, y)
     self:setAnimation("battle/idle")
 
     self.action = nil
-
+    
     self.defending = false
-    self.hurt_timer = 0
+    self.hurt_timer = 16
     self.hurting = false
 
     self.is_down = false
@@ -127,8 +127,7 @@ function PartyBattler:hurt(amount, exact, color, options)
         self:statusMessage("damage", amount, color, true)
     end
 
-    self.sprite.x = -10
-    self.hurt_timer = 4
+    self.hurt_timer = 0
     Game.battle:shakeCamera(4)
 
     if (not self.defending) and (not self.is_down) then
@@ -337,10 +336,11 @@ function PartyBattler:update()
             self.chara:getArmor(i):onBattleUpdate(self)
         end
     end
-
-    if self.hurt_timer > 0 then
-        self.sprite.x = -self.hurt_timer * 2
-        self.hurt_timer = Utils.approach(self.hurt_timer, 0, DTMULT)
+    
+    if self.hurt_timer <= 15 then
+        local hurt_index = math.min(self.hurt_timer / 2, 2)
+        self.sprite.x = (-10 + (math.floor(hurt_index) * 5))
+        self.hurt_timer = self.hurt_timer + DTMULT
     else
         self.sprite.x = 0
     end
@@ -351,7 +351,7 @@ function PartyBattler:update()
             self.target_sprite.visible = true
         end
     elseif self.should_darken then
-        if (self.darken_timer < 15) then
+        if self.darken_timer < 15 then
             self.darken_timer = self.darken_timer + DTMULT
         end
     else

--- a/src/engine/menu/mainmenucredits.lua
+++ b/src/engine/menu/mainmenucredits.lua
@@ -54,7 +54,7 @@ function MainMenuCredits:init(menu)
                 "Simbel",
                 "sjl057",
                 "skarph",
-                "",
+                "Scarm",
                 "",
                 "",
                 "",

--- a/src/engine/menu/mainmenucredits.lua
+++ b/src/engine/menu/mainmenucredits.lua
@@ -51,10 +51,10 @@ function MainMenuCredits:init(menu)
             {
                 {"GitHub Contributors", COLORS.silver},
                 "prokube",
+                "Scarm",
                 "Simbel",
                 "sjl057",
                 "skarph",
-                "Scarm",
                 "",
                 "",
                 "",


### PR DESCRIPTION
[Original Discord thread link](https://discord.com/channels/899153719248191538/1184509467870634067)

This fixes/implements the animation where if hit the PartyBattler gets pushed back.

Vanilla Kristal's pushback animation:

https://github.com/KristalTeam/Kristal/assets/82760388/f2a39655-5d70-4e83-b81f-7cf882799360

Deltarune's pushback animation:

https://github.com/KristalTeam/Kristal/assets/82760388/cfcf6d6f-a732-4faf-8389-6574d225f932

Pushback animation with the fix:


https://github.com/KristalTeam/Kristal/assets/82760388/75491ca2-52ff-4cb3-8493-d3289b09e45e

Notes:
My fix uses the Deltarune code.