### PR TITLE
Accuracy fix for DarkMenu, HealthBar, BattleUI and ActionBox transition animations

### DIFF
--- a/src/engine/game/battle/ui/actionbox.lua
+++ b/src/engine/game/battle/ui/actionbox.lua
@@ -4,8 +4,7 @@ local ActionBox, super = Class(Object)
 
 function ActionBox:init(x, y, index, battler)
     super.init(self, x, y)
-
-    self.animation_timer = 0
+    
     self.selection_siner = 0
 
     self.index = index
@@ -34,7 +33,7 @@ function ActionBox:init(x, y, index, battler)
         self.box:addChild(self.name_sprite)
     end
 
-    self.hp_sprite   = Sprite("ui/hp", 109, 22)
+    self.hp_sprite = Sprite("ui/hp", 109, 22)
 
     self.box:addChild(self.head_sprite)
     self.box:addChild(self.hp_sprite)
@@ -109,37 +108,26 @@ function ActionBox:resetHeadIcon()
 end
 
 function ActionBox:update()
-    if (Game.battle.current_selecting == self.index) then
-        self.animation_timer = self.animation_timer + 1 * DTMULT
-    else
-        self.animation_timer = self.animation_timer - 1 * DTMULT
-    end
-
-    if self.animation_timer > 7 then
-        self.animation_timer = 7
-    end
-
-    if (Game.battle.current_selecting ~= self.index) and (self.animation_timer > 3) then
-        self.animation_timer = 3
-    end
-
-    if self.animation_timer < 0 then
-        self.animation_timer = 0
-    end
-
     self.selection_siner = self.selection_siner + 2 * DTMULT
 
     if Game.battle.current_selecting == self.index then
-        self.box.y = -Ease.outCubic(self.animation_timer, 0, 32, 7)
+        if self.box.y > -32 then self.box.y = self.box.y - 2 * DTMULT end
+        if self.box.y > -24 then self.box.y = self.box.y - 4 * DTMULT end
+        if self.box.y > -16 then self.box.y = self.box.y - 6 * DTMULT end
+        if self.box.y > -8  then self.box.y = self.box.y - 8 * DTMULT end
+        -- originally '= -64' but that was an oversight by toby
+        if self.box.y < -32 then self.box.y = -32 end
+    elseif self.box.y < -14 then
+        self.box.y = self.box.y + 15 * DTMULT
     else
-        self.box.y = -Ease.outCubic(3 - self.animation_timer, 32, -32, 3)
+        self.box.y = 0
     end
 
     self.head_sprite.y = 11 - self.data_offset + self.head_offset_y
     if self.name_sprite then
         self.name_sprite.y = 14 - self.data_offset
     end
-    self.hp_sprite.y   = 22 - self.data_offset
+    self.hp_sprite.y = 22 - self.data_offset
 
     if not self.force_head_sprite then
         local current_head = self.battler.chara:getHeadIcons().."/"..self.battler:getHeadIcon()

--- a/src/engine/game/battle/ui/battleui.lua
+++ b/src/engine/game/battle/ui/battleui.lua
@@ -64,7 +64,7 @@ function BattleUI:init()
     self.animation_timer = 0
     self.animate_out = false
 
-    self.transition_y = 0
+    self.animation_y = 0
 
     self.shown = false
 
@@ -157,37 +157,37 @@ function BattleUI:update()
 
         for _, box in ipairs(self.action_boxes) do
             if not self.animate_out then
-                box.data_offset = self.transition_y - transition_target
+                box.data_offset = self.animation_y - transition_target
             else
                 -- not exactly accurate, but it's close enough
-                -- this is due to Kristal updating code faster than 30 steps like in GameMaker
+                -- this is due to Kristal updating code independently from framerate
                 box.data_offset = Utils.ease(30, 0, self.animation_timer / 5, "linear")
             end
         end
 
         if not self.animate_out then
-            if self.transition_y < transition_target then
-                if transition_target - self.transition_y < 40 then
-                    self.transition_y = self.transition_y + math.ceil((transition_target - self.transition_y) / 2.5) * DTMULT
+            if self.animation_y < transition_target then
+                if transition_target - self.animation_y < 40 then
+                    self.animation_y = self.animation_y + math.ceil((transition_target - self.animation_y) / 2.5) * DTMULT
                 else
-                    self.transition_y = self.transition_y + 30 * DTMULT
+                    self.animation_y = self.animation_y + 30 * DTMULT
                 end
             else
-                self.transition_y = transition_target
+                self.animation_y = transition_target
             end
         else
-            if self.transition_y > -3 then
-                if math.floor((transition_target - self.transition_y) / 5) > 15 then
-                    self.transition_y = self.transition_y - math.floor((transition_target - self.transition_y) / 2.5) * DTMULT
+            if self.animation_y > -3 then
+                if math.floor((transition_target - self.animation_y) / 5) > 15 then
+                    self.animation_y = self.animation_y - math.floor((transition_target - self.animation_y) / 2.5) * DTMULT
                 else
-                    self.transition_y = self.transition_y - 30 * DTMULT
+                    self.animation_y = self.animation_y - 30 * DTMULT
                 end
             else
-                self.transition_y = -3
+                self.animation_y = -3
             end
         end
 
-        self.y = (480 - self.transition_y) - 3
+        self.y = (480 - self.animation_y) - 3
     end
 
     if self.attacking then

--- a/src/engine/game/world/ui/dark/darkmenu.lua
+++ b/src/engine/game/world/ui/dark/darkmenu.lua
@@ -267,11 +267,26 @@ function DarkMenu:update()
         end
     end
 
-    local offset
     if not self.animate_out then
-        self.y = Ease.outCubic(math.min(max_time, self.animation_timer), -80, 80, max_time)
+        if self.y < 0 then
+            if self.y > -40 then
+                self.y = self.y + math.ceil(-self.y / 2.5) * DTMULT
+            else
+                self.y = self.y + 30 * DTMULT
+            end
+        else
+            self.y = 0
+        end
     else
-        self.y = Ease.outCubic(math.min(max_time, self.animation_timer), 0, -80, max_time)
+        if self.y > -80 then
+            if self.y > 0 then
+                self.y = self.y - math.floor(self.y / 2.5) * DTMULT
+            else
+                self.y = self.y - 30 * DTMULT
+            end
+        else
+            self.y = -80
+        end
     end
 
     super.update(self)

--- a/src/engine/game/world/ui/healthbar.lua
+++ b/src/engine/game/world/ui/healthbar.lua
@@ -13,6 +13,7 @@ function HealthBar:init()
     self.animation_done = false
     self.animation_timer = 0
     self.animate_out = false
+    self.animation_y = -63
 
     self.action_boxes = {}
 
@@ -79,10 +80,28 @@ function HealthBar:update()
     end
 
     if not self.animate_out then
-        self.y = Ease.outCubic(math.min(max_time, self.animation_timer), 417 + 63, -63, max_time)
+        if self.animation_y < 0 then
+            if self.animation_y > -40 then
+                self.animation_y = self.animation_y + math.ceil(-self.animation_y / 2.5) * DTMULT
+            else
+                self.animation_y = self.animation_y + 30 * DTMULT
+            end
+        else
+            self.animation_y = 0
+        end
     else
-        self.y = Ease.outCubic(math.min(max_time, self.animation_timer), 417, 63, max_time)
+        if self.animation_y > -63 then
+            if self.animation_y > 0 then
+                self.animation_y = self.animation_y - math.floor(self.animation_y / 2.5) * DTMULT
+            else
+                self.animation_y = self.animation_y - 30 * DTMULT
+            end
+        else
+            self.animation_y = -63
+        end
     end
+
+    self.y = 480 - (self.animation_y + 63)
 
     super.update(self)
 end


### PR DESCRIPTION
This PR implements code-accurate animations for dark UI.

DarkMenu, HealthBar & BattleUI transitions now use the rounded lerp functions found in Deltarune, although I have made them into floor/ceil functions as they break on framerates > 30fps if rounded.

ActionBox easing functions have been replaced by the weird fake lerp found in Deltarune, with a minor fix which was an oversight in Deltarune itself (check comment)

ActionBox's `data_offset` now also almost matches the Deltarune one ("almost" because the out transition cannot be done because lack of "spaghetti code" + see comment on line 162 in `battleui.lua`, however when transitioning in, it is code-accurate)
