### PR TITLE
BattleUI Fix & Cleanup for Previous Accuracy PR

### DIFF
--- a/src/engine/game/battle/ui/battleui.lua
+++ b/src/engine/game/battle/ui/battleui.lua
@@ -172,14 +172,14 @@ function BattleUI:update()
         else
             self.animation_y_lag = Utils.approach(self.animation_y_lag, self.y, 30 * DTMULT)
 
-            if self.animation_y > -3 then
+            if self.animation_y > 0 then
                 if math.floor((target - self.animation_y) / 5) > 15 then
                     self.animation_y = self.animation_y - math.floor((target - self.animation_y) / 2.5) * DTMULT
                 else
                     self.animation_y = self.animation_y - 30 * DTMULT
                 end
             else
-                self.animation_y = -3
+                self.animation_y = 0
             end
         end
         

--- a/src/engine/game/battle/ui/battleui.lua
+++ b/src/engine/game/battle/ui/battleui.lua
@@ -27,7 +27,6 @@ function BattleUI:init()
     self:addChild(self.short_act_text_2)
     self:addChild(self.short_act_text_3)
 
-
     self.action_boxes = {}
     self.attack_boxes = {}
 
@@ -35,6 +34,7 @@ function BattleUI:init()
 
     local size_offset = 0
     local box_gap = 0
+    
     if #Game.battle.party == 3 then
         size_offset = 0
         box_gap = 0
@@ -49,7 +49,6 @@ function BattleUI:init()
         size_offset = 213
         box_gap = 0
     end
-
 
     for index,battler in ipairs(Game.battle.party) do
         local action_box = ActionBox(size_offset+ (index - 1) * (213 + box_gap), 0, index, battler)

--- a/src/engine/game/battle/ui/battleui.lua
+++ b/src/engine/game/battle/ui/battleui.lua
@@ -183,7 +183,7 @@ function BattleUI:update()
             end
         end
         
-        self.y = 480 - self.animation_y
+        self.y = lower - self.animation_y
 
         for _, box in ipairs(self.action_boxes) do
             if not self.animate_out then

--- a/src/engine/game/battle/ui/battleui.lua
+++ b/src/engine/game/battle/ui/battleui.lua
@@ -27,6 +27,7 @@ function BattleUI:init()
     self:addChild(self.short_act_text_2)
     self:addChild(self.short_act_text_3)
 
+
     self.action_boxes = {}
     self.attack_boxes = {}
 
@@ -65,6 +66,7 @@ function BattleUI:init()
     self.animate_out = false
 
     self.animation_y = 0
+    self.animation_y_lag = 0
 
     self.shown = false
 
@@ -138,6 +140,7 @@ function BattleUI:transitionOut()
         self.animate_out = true
         self.animation_timer = 0
         self.animation_done = false
+        self.animation_y_lag = self.y
         self.shown = false
     end
 end
@@ -153,32 +156,25 @@ function BattleUI:update()
             self.animation_timer = max_time + 1
         end
 
-        local transition_target = 152
-
-        for _, box in ipairs(self.action_boxes) do
-            if not self.animate_out then
-                box.data_offset = self.animation_y - transition_target
-            else
-                -- not exactly accurate, but it's close enough
-                -- this is due to Kristal updating code independently from framerate
-                box.data_offset = Utils.ease(30, 0, self.animation_timer / 5, "linear")
-            end
-        end
+        local lower, upper = self:getTransitionBounds()
+        local target = lower - upper
 
         if not self.animate_out then
-            if self.animation_y < transition_target then
-                if transition_target - self.animation_y < 40 then
-                    self.animation_y = self.animation_y + math.ceil((transition_target - self.animation_y) / 2.5) * DTMULT
+            if self.animation_y < target then
+                if target - self.animation_y < 40 then
+                    self.animation_y = self.animation_y + math.ceil((target - self.animation_y) / 2.5) * DTMULT
                 else
                     self.animation_y = self.animation_y + 30 * DTMULT
                 end
             else
-                self.animation_y = transition_target
+                self.animation_y = target
             end
         else
+            self.animation_y_lag = Utils.approach(self.animation_y_lag, self.y, 30 * DTMULT)
+
             if self.animation_y > -3 then
-                if math.floor((transition_target - self.animation_y) / 5) > 15 then
-                    self.animation_y = self.animation_y - math.floor((transition_target - self.animation_y) / 2.5) * DTMULT
+                if math.floor((target - self.animation_y) / 5) > 15 then
+                    self.animation_y = self.animation_y - math.floor((target - self.animation_y) / 2.5) * DTMULT
                 else
                     self.animation_y = self.animation_y - 30 * DTMULT
                 end
@@ -186,8 +182,16 @@ function BattleUI:update()
                 self.animation_y = -3
             end
         end
+        
+        self.y = 480 - self.animation_y
 
-        self.y = (480 - self.animation_y) - 3
+        for _, box in ipairs(self.action_boxes) do
+            if not self.animate_out then
+                box.data_offset = self.animation_y - target
+            else
+                box.data_offset = self.y - self.animation_y_lag
+            end
+        end
     end
 
     if self.attacking then


### PR DESCRIPTION
This PR is for cleaning up a few things and somewhat fixing the `data_offset` issue discussed [here](https://discord.com/channels/899153719248191538/900580330501709854/1185251074064535712) from [this pr](https://github.com/KristalTeam/Kristal/pull/88)

Changes:
- Renamed `self.transition_y` and others to `self.animation_*` for consistency with the other animation variables.
- Made the animation work with `self:getTransitionBounds()` (not sure why I didn't do it from the start...).
- Re-implemented the `data_offset` delay better, but this time it's not weird on higher framerates (Note: The `data_offset` shrinks on higher framerates, and the previous statement refers to a visual bug.)

About the third change, it still looks close enough and for someone who's not an accuracy nut, it shouldn't be a visual bother.
Demonstration footage:

Control:

https://github.com/KristalTeam/Kristal/assets/82760388/b45f7669-365b-4b6d-9f8e-8915200f2314

30 FPS:

https://github.com/KristalTeam/Kristal/assets/82760388/b354bbca-c522-43fc-aca8-62c7b3178051

Unlimited FPS:

https://github.com/KristalTeam/Kristal/assets/82760388/dbae4cfc-a05c-441c-8463-4836fa4b70fa

Comparison (Deltarune & 30 FPS Video):

https://github.com/KristalTeam/Kristal/assets/82760388/33a3b07c-c4bb-4583-8e90-aeac20234814

