### PR TITLE
Added Volume and Pitch as options for Mod:onMapMusic()

### DIFF
--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -736,20 +736,32 @@ function World:loadMap(...)
 end
 
 function World:transitionMusic(next, fade_out)
-    if next and next ~= "" then
-        if self.music.current ~= next then
+    -- Compatibility with older versions of transitionMusic which have "next" as the music
+    local music = ""
+    local volume = 1
+    local pitch = 1
+    if type(next) == "table" then
+        music = next[1]
+        volume = next[2]
+        pitch = next[3]
+    else
+        music = next
+    end
+    --
+    if music and music ~= "" then
+        if self.music.current ~= music then
             if self.music:isPlaying() and fade_out then
                 self.music:fade(0, 10/30, function() self.music:stop() end)
             elseif not fade_out then
-                self.music:play(next, 1)
+                self.music:play(music, volume, pitch)
             end
         else
             if not self.music:isPlaying() then
                 if not fade_out then
-                    self.music:play(next, 1)
+                    self.music:play(music, volume, pitch)
                 end
             else
-                self.music:fade(1)
+                self.music:fade(volume)
             end
         end
     else


### PR DESCRIPTION
now if you'd like to play your map's music at double the volume and half the pitch, you'd do

```lua
function Mod:onMapMusic(map, music)
    return {music, 2, 0.5}
end
```

and, it has compatibility with the old version of the transitionMusic() function, so you can still use it the old way:

```lua
function Mod:onMapMusic(map, music)
    return music
end
```