### PR TITLE
onMapBorder mod call

### DIFF
--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -682,7 +682,7 @@ function World:setupMap(map, ...)
 
     local map_border = self.map:getBorder(dark_transitioned)
     if map_border then
-        Game:setBorder(map_border)
+        Game:setBorder(Kristal.callEvent("onMapBorder", self.map, map_border) or map_border)
     end
 
     if not self.map.keep_music then
@@ -827,7 +827,7 @@ function World:mapTransition(...)
         local dark_transition = map.light ~= Game:isLight()
         local map_border = map:getBorder(dark_transition)
         if map_border then
-            Game:setBorder(map_border, 1)
+            Game:setBorder(Kristal.callEvent("onMapBorder", self.map, map_border) or map_border, 1)
         end
     end
     self:fadeInto(function()

--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -736,20 +736,32 @@ function World:loadMap(...)
 end
 
 function World:transitionMusic(next, fade_out)
-    if next and next ~= "" then
-        if self.music.current ~= next then
+    -- Compatibility with older versions of transitionMusic which have "next" as the music
+    local music = ""
+    local volume = 1
+    local pitch = 1
+    if type(next) == "table" then
+        music = next[1]
+        volume = next[2]
+        pitch = next[3]
+    else
+        music = next
+    end
+    --
+    if music and music ~= "" then
+        if self.music.current ~= music then
             if self.music:isPlaying() and fade_out then
                 self.music:fade(0, 10/30, function() self.music:stop() end)
             elseif not fade_out then
-                self.music:play(next, 1)
+                self.music:play(music, volume, pitch)
             end
         else
             if not self.music:isPlaying() then
                 if not fade_out then
-                    self.music:play(next, 1)
+                    self.music:play(music, volume, pitch)
                 end
             else
-                self.music:fade(1)
+                self.music:fade(volume)
             end
         end
     else


### PR DESCRIPTION
Like Mod:onMapMusic, but for borders. An example of why someone would want this is if they have a map that has two different 'areas' with different borders, that change as they advance through the map.

Code example:
```
function Mod:onMapBorder(map, border)
    if map.name == "name" and (border == "cyber") then
        if Game:getFlag("flag", false) == true then
            return "city"
        end
        return border
    end
end
```