### PR TITLE
onActionSelect and onCharacterTurn fix

### DIFF
--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -1910,11 +1910,10 @@ function Battle:nextParty()
         if self:getState() ~= "ACTIONSELECT" then
             self:setState("ACTIONSELECT")
             self.battle_ui.encounter_text:setText("[instant]" .. self.battle_ui.current_encounter_text)
-        else
-            local party = self.party[self.current_selecting]
-            party.chara:onActionSelect(party, false)
-            self.encounter:onCharacterTurn(party, false)
         end
+        local party = self.party[self.current_selecting]
+        party.chara:onActionSelect(party, false)
+        self.encounter:onCharacterTurn(party, false)
     end
 end
 
@@ -2033,6 +2032,12 @@ function Battle:nextTurn()
         for _,party in ipairs(self.party) do
             party.chara:onTurnStart(party)
         end
+    end
+
+    -- bad solution
+    if self.turn_count > 1 then
+        self.party[1].chara:onActionSelect(self.party[1], false)
+        self.encounter:onCharacterTurn(self.party[1], false)
     end
 
     if self.current_selecting ~= 0 then


### PR DESCRIPTION
previously they wouldn't trigger if a battler didn't select defend or on the first character in the party's turn starts on a new turn