### PR TITLE
fix twinribbon and autoaxe bonus stats

### DIFF
--- a/data/items/armors/twinribbon.lua
+++ b/data/items/armors/twinribbon.lua
@@ -34,7 +34,7 @@ function item:init()
 
     -- Equip bonuses (for weapons and armor)
     self.bonuses = {
-        defense = 1,
+        defense = 3,
 
         graze_size = 0.2,
     }

--- a/data/items/weapons/autoaxe.lua
+++ b/data/items/weapons/autoaxe.lua
@@ -34,7 +34,7 @@ function item:init()
 
     -- Equip bonuses (for weapons and armor)
     self.bonuses = {
-        attack = 2,
+        attack = 4,
     }
     -- Bonus name and icon (displayed in equip menu)
     self.bonus_name = "BadIdea"


### PR DESCRIPTION
TwinRibbon's defense stat changed from 1 -> 3 and AutoAxe's attack stat changed from 2 -> 4 to match their values in DELTARUNE