### PR TITLE
setWindowTitle improvements

### DIFF
--- a/mod_template/mod.json
+++ b/mod_template/mod.json
@@ -53,7 +53,8 @@
 
     // Whether the game window's title should be set to the mod's name. When your mod is
     // configured as the engine's target mod, this is true by default; vice versa otherwise.
-    "setWindowTitle": true,
+    // Here, specifying "null" essentially makes the engine decide for you.
+    "setWindowTitle": null,
 
     // Config values for the engine and any libraries you may have.
     // These config values can control chapter-specific features as well.

--- a/mod_template/mod.json
+++ b/mod_template/mod.json
@@ -51,8 +51,8 @@
     // Whether the mod is hidden from the mod selection.
     "hidden": false,
 
-    // Whether the game window's title should be set to the mod's name, when the engine is run
-    // with this mod as the target mod.
+    // Whether the game window's title should be set to the mod's name. When your mod is
+    // configured as the engine's target mod, this is true by default; vice versa otherwise.
     "setWindowTitle": true,
 
     // Config values for the engine and any libraries you may have.

--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -895,7 +895,7 @@ function Kristal.clearModState()
     Assets.restoreData()
     Registry.initialize()
     love.window.setIcon(Kristal.icon)
-    love.window.setTitle(Kristal.game_default_name)
+    love.window.setTitle(Kristal.getDesiredWindowTitle())
 end
 
 --- Exits the current mod and returns to the Kristal menu.
@@ -950,6 +950,7 @@ function Kristal.quickReload(mode)
             Kristal.loadMod(mod_id, nil, nil, function ()
                 -- Pre-initialize the current mod
                 if Kristal.preInitMod(mod_id) then
+                    love.window.setTitle(Kristal.getDesiredWindowTitle())
                     -- Switch to Game and load the temp save
                     Gamestate.switch(Game)
                     if save then
@@ -1073,6 +1074,7 @@ function Kristal.loadMod(id, save_id, save_name, after)
 
     Kristal.loadModAssets(mod.id, "all", "", after or function ()
         if Kristal.preInitMod(mod.id) then
+            love.window.setTitle(Kristal.getDesiredWindowTitle())
             Gamestate.switch(Kristal.States["Game"], save_id, save_name)
         end
     end)
@@ -1118,10 +1120,16 @@ end
 
 --- Called internally. Gets the intended title of the game window.
 function Kristal.getDesiredWindowTitle()
-    local target_mod = TARGET_MOD and Kristal.Mods.getMod(TARGET_MOD)
-    local use_target_mod_name = target_mod
-        and (target_mod.setWindowTitle == nil or target_mod.setWindowTitle)
-    return use_target_mod_name and target_mod.name or Kristal.game_default_name
+    local mod = TARGET_MOD and Kristal.Mods.getMod(TARGET_MOD) or (Mod and Mod.info)
+    local use_mod_name = false
+    if mod then
+        if TARGET_MOD then
+            use_mod_name = mod.setWindowTitle ~= false
+        else
+            use_mod_name = mod.setWindowTitle
+        end
+    end
+    return use_mod_name and mod.name or Kristal.game_default_name
 end
 
 --- Called internally. Calls the `preInit` event on the mod and initializes the registry.


### PR DESCRIPTION
- Under normal mode, the engine will change the window title if setWindowTitle is true. This makes it work like CYF
- Under target mod mode, the engine will always change the window title, unless setWindowTitle is explicitly set to false
- Mod template sets setWindowTitle to nil to let the engine decide what it will do, while keeping the property from being undocumented