### PR TITLE
Improved World:getPartyCharacter(party) function 

### DIFF
--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -439,16 +439,16 @@ function World:getPartyCharacter(party)
     if type(party) == "string" then
         party = Game:getPartyMember(party)
     end
-    local char = self.player
     if party ~= self.player:getPartyMember() then
         for _,follower in ipairs(self.followers) do
             if Game:hasPartyMember(follower:getPartyMember()) and party == follower:getPartyMember() then
-                char = follower
+                return follower
                 break
             end
         end
+    else
+        return self.player
     end
-    return char
 end
 
 function World:removeFollower(chara)

--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -442,7 +442,7 @@ function World:getPartyCharacter(party)
     local char = self.player
     if party ~= self.player:getPartyMember() then
         for _,follower in ipairs(self.followers) do
-            if party == follower:getPartyMember() then
+            if Game:hasPartyMember(follower:getPartyMember()) and party == follower:getPartyMember() then
                 char = follower
                 break
             end

--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -439,11 +439,16 @@ function World:getPartyCharacter(party)
     if type(party) == "string" then
         party = Game:getPartyMember(party)
     end
-    for _,char in ipairs(Game.stage:getObjects(Character)) do
-        if char.actor and char.actor.id == party:getActor().id then
-            return char
+    local char = self.player
+    if party ~= char:getPartyMember() then
+        for _,follower in ipairs(self.followers) do
+            if party == follower:getPartyMember() then
+                char = follower
+                break
+            end
         end
     end
+    return char
 end
 
 function World:removeFollower(chara)

--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -445,7 +445,6 @@ function World:getPartyCharacter(party)
         for _,follower in ipairs(self.followers) do
             if Game:hasPartyMember(follower:getPartyMember()) and party == follower:getPartyMember() then
                 return follower
-                break
             end
         end
     end

--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -439,15 +439,15 @@ function World:getPartyCharacter(party)
     if type(party) == "string" then
         party = Game:getPartyMember(party)
     end
-    if party ~= self.player:getPartyMember() then
+    if party == self.player:getPartyMember() then
+        return self.player
+    else
         for _,follower in ipairs(self.followers) do
             if Game:hasPartyMember(follower:getPartyMember()) and party == follower:getPartyMember() then
                 return follower
                 break
             end
         end
-    else
-        return self.player
     end
 end
 

--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -440,7 +440,7 @@ function World:getPartyCharacter(party)
         party = Game:getPartyMember(party)
     end
     local char = self.player
-    if party ~= char:getPartyMember() then
+    if party ~= self.player:getPartyMember() then
         for _,follower in ipairs(self.followers) do
             if party == follower:getPartyMember() then
                 char = follower


### PR DESCRIPTION
It will no longer target NPCs, only the party train, fixing a bug where the overworld soul would spawn on an NPC if the soul party character presents with the same NPC id.