### PR TITLE
Mod-defined custom soul colors in mod select

### DIFF
--- a/src/engine/menu/mainmenufileselect.lua
+++ b/src/engine/menu/mainmenufileselect.lua
@@ -181,6 +181,9 @@ function MainMenuFileSelect:onKeyPressed(key, is_repeat)
         if Input.is("cancel", key) then
             if not TARGET_MOD then
                 self.menu:setState("MODSELECT")
+				if MainMenu.mod_list:getSelectedMod().soulColor then
+					MainMenu.heart.color = MainMenu.mod_list:getSelectedMod().soulColor
+				end
             else
                 self.menu:setState("TITLE")
                 self.menu.title_screen:selectOption("play")
@@ -212,6 +215,9 @@ function MainMenuFileSelect:onKeyPressed(key, is_repeat)
                 elseif self.selected_x == 3 then
                     if not TARGET_MOD then
                         self.menu:setState("MODSELECT")
+						if MainMenu.mod_list:getSelectedMod().soulColor then
+							MainMenu.heart.color = MainMenu.mod_list:getSelectedMod().soulColor
+						end
                     else
                         self.menu:setState("TITLE")
                         self.menu.title_screen:selectOption("play")

--- a/src/engine/menu/mainmenutitle.lua
+++ b/src/engine/menu/mainmenutitle.lua
@@ -68,6 +68,9 @@ function MainMenuTitle:onKeyPressed(key, is_repeat)
         if option == "play" then
             if not TARGET_MOD then
                 self.menu:setState("MODSELECT")
+				if MainMenu.mod_list:getSelectedMod().soulColor then
+					MainMenu.heart.color = MainMenu.mod_list:getSelectedMod().soulColor
+				end
             elseif self.has_target_saves then
                 self.menu:setState("FILESELECT")
             else

--- a/src/engine/objects/gonerchoice.lua
+++ b/src/engine/objects/gonerchoice.lua
@@ -29,7 +29,10 @@ function GonerChoice:init(x, y, choices, on_complete, on_select)
 
     self.soul = Sprite("player/heart_blur")
     self.soul:setScale(2, 2)
-    self.soul:setColor(1, 0, 0)
+    self.soul:setColor(Kristal.getSoulColor())
+	if MainMenu.mod_list:getSelectedMod().soulColor then	-- Add Game detection
+		self.soul:setColor(unpack(MainMenu.mod_list:getSelectedMod().soulColor))
+	end
     self.soul.alpha = 0.6
     self.soul.inherit_color = true
     self:addChild(self.soul)

--- a/src/engine/objects/gonerchoice.lua
+++ b/src/engine/objects/gonerchoice.lua
@@ -30,7 +30,7 @@ function GonerChoice:init(x, y, choices, on_complete, on_select)
     self.soul = Sprite("player/heart_blur")
     self.soul:setScale(2, 2)
     self.soul:setColor(Kristal.getSoulColor())
-	if MainMenu.mod_list:getSelectedMod().soulColor then	-- Add Game detection
+	if MainMenu.mod_list:getSelectedMod().soulColor and Kristal.getState() ~= Game then
 		self.soul:setColor(unpack(MainMenu.mod_list:getSelectedMod().soulColor))
 	end
     self.soul.alpha = 0.6


### PR DESCRIPTION
To use it, just define `"soulColor": [1, 0, 0]` in your `mod.json` file.