### PR TITLE
add getters for mirror sprites

### DIFF
--- a/src/engine/game/common/data/actor.lua
+++ b/src/engine/game/common/data/actor.lua
@@ -147,6 +147,9 @@ function Actor:getTalkSpeed(sprite) return self.talk_sprites[sprite] or 0.25 end
 
 function Actor:getAnimation(anim) return self.animations[anim] end
 
+function Actor:getMirrorSprites() return self.mirror_sprites end
+function Actor:getMirrorSprite(sprite) return self:getMirrorSprites()[sprite] end
+
 function Actor:hasOffset(sprite) return self.offsets[sprite] ~= nil end
 function Actor:getOffset(sprite) return unpack(self.offsets[sprite] or {0, 0}) end
 

--- a/src/engine/game/world/events/mirror.lua
+++ b/src/engine/game/world/events/mirror.lua
@@ -35,7 +35,7 @@ function MirrorArea:drawCharacter(chara)
     local pathless = t[1]
     local frame = t[2]
     local newsprite = oldsprite
-    local mirror = chara.actor.mirror_sprites
+    local mirror = chara.actor:getMirrorSprites()
     if mirror and mirror[pathless] then
         newsprite = mirror[pathless] .. "_" .. frame
     end


### PR DESCRIPTION
the mirror sprites table for actors now has two getter functions `getMirrorSprite(sprite)` and `getMirrorSprites()` that retrieve the data so that you can more easily implement dynamic changes to mirror sprites i.e. a change to the mirror sprites on a particular route controlled by a flag - henceforth the mirror object uses `getMirrorSprites()` rather than directly retreiving the table now