### PR TITLE
Shop function to delete talks in self.talks array

### DIFF
--- a/src/engine/game/shop.lua
+++ b/src/engine/game/shop.lua
@@ -482,6 +482,14 @@ function Shop:registerTalk(talk, color)
     table.insert(self.talks, {talk, {color=color or COLORS.white}})
 end
 
+function Shop:deleteTalk(index)
+    if self.talks[index] then
+        table.remove(self.talks, index)
+    else
+        print("Talk not found at index: " .. tostring(index))
+    end
+end
+
 function Shop:replaceTalk(talk, index, color)
     self.talks[index] = {talk, {color=color or COLORS.yellow}}
 end

--- a/src/engine/game/shop.lua
+++ b/src/engine/game/shop.lua
@@ -482,7 +482,7 @@ function Shop:registerTalk(talk, color)
     table.insert(self.talks, {talk, {color=color or COLORS.white}})
 end
 
-function Shop:deleteTalk(index)
+function Shop:removeTalk(index)
     if self.talks[index] then
         table.remove(self.talks, index)
     else


### PR DESCRIPTION
I've added a new function, `Shop:deleteTalk(index)`, to the Shop class. This is a simple function that allows easy removal of a specific talk entry from the `self.talks` table.

The existing `replaceTalk` function was insufficient for cases where a talk needed to be completely removed from the table rather than replaced by another.

I know this addition might look quite specific but I think it's a missing piece on the register/replace combo, as deleting can be handy in a lot of situations. It can be particularly useful in scenarios where dynamic modifications to the talks are required. For example, when a talk should only be present under certain conditions or flags, the ability to remove specific talks ensures the `self.talks` array remains clean and helps avoid potential duplicates.

Changes I've made:
```lua
function Shop:deleteTalk(index)
    if self.talks[index] then
        table.remove(self.talks, index)
    else
        print("Talk not found at index: " .. tostring(index))
    end
end
```

The function checks if the specified index exists in the `self.talks` table before attempting to remove it, providing a safeguard against potential errors.
I've also added a print statement when the index doesn't exist to notify that the talk was not found. But this is optional, you can remove it if you wish.

Also, you can use this other code to monitor what's happening in the `self.talks` array, as well as the other array for replacements (used within `registerTalkAfter()`). I added this function inside `startTalk()` in my mod's shop to debug.

```lua
    -- (DEBUG) Monitor talks table
    for i = 1, #self.talks do
        if self.talks[i] then
            print(self.talks[i][1])
        end
    end

    -- (DEBUG) Monitor talk_replacements table
    for i = 1, #self.talks do
        for j = 1, #self.talk_replacements do
            if self.talk_replacements[j][1] == i then
                print("---------- TALK NUMBER # " .. i .. " ----------")
                print(self.talk_replacements[j][2][1])
            end
        end
    end
```

Could be interesting to make a `deleteTalkAfter()` function too, as these are controlled by a different array (`self.talk_replacements`). If this PR is approved, I can check that out next :) 

