### PR TITLE
Added Draw.printAlign()

### DIFF
--- a/src/engine/game/world/ui/recruitmenu.lua
+++ b/src/engine/game/world/ui/recruitmenu.lua
@@ -176,9 +176,9 @@ function RecruitMenu:draw()
             if i <= self:getLastSelectedInPage() and i >= self:getFirstSelectedInPage() then
                 Draw.setColor(COLORS["white"])
                 if i == self.selected then
-                    love.graphics.printAlign(recruit:getName(), 473, 240, "center")
+                    Draw.printAlign(recruit:getName(), 473, 240, "center")
                     love.graphics.print("CHAPTER " .. recruit:getChapter(), 368, 280)
-                    love.graphics.printAlign("LV " .. recruit:getLevel(), 576, 280, "right")
+                    Draw.printAlign("LV " .. recruit:getLevel(), 576, 280, "right")
                     if Input.usingGamepad() then
                         love.graphics.print("More Info", 414, 320)
                         Draw.draw(Input.getTexture("confirm"), 380, 323, 0, 2, 2)
@@ -219,7 +219,7 @@ function RecruitMenu:draw()
         
         Draw.setColor(COLORS["white"])
         for i,recruit in pairs(self.recruits) do
-            love.graphics.printAlign(self.selected .. "/" .. #self.recruits, 590, 30, "right", 0, 0.5, 1)
+            Draw.printAlign(self.selected .. "/" .. #self.recruits, 590, 30, "right", 0, 0.5, 1)
             if i == self.selected then
                 love.graphics.print("CHAPTER " .. recruit:getChapter(), 300, 30, 0, 0.5, 1)
                 love.graphics.print(recruit:getName(), 300, 70)
@@ -246,12 +246,12 @@ function RecruitMenu:draw()
                     love.graphics.print("Press " .. Input.getText("cancel") .. " to Return", 80, 400)
                 end
                 love.graphics.print("LEVEL", 525, 240, 0, 0.5, 1)
-                love.graphics.printAlign(recruit:getLevel(), 590, 240, "right", 0, 0.5, 1)
+                Draw.printAlign(recruit:getLevel(), 590, 240, "right", 0, 0.5, 1)
                 love.graphics.print("ATTACK", 518, 280, 0, 0.5, 1)
-                love.graphics.printAlign(recruit:getAttack(), 590, 280, "right", 0, 0.5, 1)
+                Draw.printAlign(recruit:getAttack(), 590, 280, "right", 0, 0.5, 1)
                 love.graphics.print("DEFENSE", 511, 320, 0, 0.5, 1)
-                love.graphics.printAlign(recruit:getDefense(), 590, 320, "right", 0, 0.5, 1)
-                love.graphics.printAlign("ELEMENT " .. recruit:getElement(), 590, 360, "right", 0, 0.5, 1)
+                Draw.printAlign(recruit:getDefense(), 590, 320, "right", 0, 0.5, 1)
+                Draw.printAlign("ELEMENT " .. recruit:getElement(), 590, 360, "right", 0, 0.5, 1)
             end
             
             Draw.setColor(1, 1, 1, 1)

--- a/src/engine/game/world/ui/recruitmenu.lua
+++ b/src/engine/game/world/ui/recruitmenu.lua
@@ -176,11 +176,9 @@ function RecruitMenu:draw()
             if i <= self:getLastSelectedInPage() and i >= self:getFirstSelectedInPage() then
                 Draw.setColor(COLORS["white"])
                 if i == self.selected then
-                    local name = recruit:getName()
-                    love.graphics.print(name, 473 - self.font:getWidth(name) / 2, 240)
+                    love.graphics.printAlign(recruit:getName(), 473, 240, "center")
                     love.graphics.print("CHAPTER " .. recruit:getChapter(), 368, 280)
-                    local level = "LV " .. recruit:getLevel()
-                    love.graphics.print(level, 576 - self.font:getWidth(level), 280)
+                    love.graphics.printAlign("LV " .. recruit:getLevel(), 576, 280, "right")
                     if Input.usingGamepad() then
                         love.graphics.print("More Info", 414, 320)
                         Draw.draw(Input.getTexture("confirm"), 380, 323, 0, 2, 2)
@@ -221,8 +219,7 @@ function RecruitMenu:draw()
         
         Draw.setColor(COLORS["white"])
         for i,recruit in pairs(self.recruits) do
-            local selection = self.selected .. "/" .. #self.recruits
-            love.graphics.print(selection, 590 - self.font:getWidth(selection) / 2, 30, 0, 0.5, 1)
+            love.graphics.printAlign(self.selected .. "/" .. #self.recruits, 590, 30, "right", 0, 0.5, 1)
             if i == self.selected then
                 love.graphics.print("CHAPTER " .. recruit:getChapter(), 300, 30, 0, 0.5, 1)
                 love.graphics.print(recruit:getName(), 300, 70)
@@ -248,21 +245,13 @@ function RecruitMenu:draw()
                 else
                     love.graphics.print("Press " .. Input.getText("cancel") .. " to Return", 80, 400)
                 end
-                
                 love.graphics.print("LEVEL", 525, 240, 0, 0.5, 1)
-                local level = recruit:getLevel()
-                love.graphics.print(level, 590 - self.font:getWidth(level) / 2, 240, 0, 0.5, 1)
-                
+                love.graphics.printAlign(recruit:getLevel(), 590, 240, "right", 0, 0.5, 1)
                 love.graphics.print("ATTACK", 518, 280, 0, 0.5, 1)
-                local attack = recruit:getAttack()
-                love.graphics.print(attack, 590 - self.font:getWidth(attack) / 2, 280, 0, 0.5, 1)
-                
+                love.graphics.printAlign(recruit:getAttack(), 590, 280, "right", 0, 0.5, 1)
                 love.graphics.print("DEFENSE", 511, 320, 0, 0.5, 1)
-                local defense = recruit:getDefense()
-                love.graphics.print(defense, 590 - self.font:getWidth(defense) / 2, 320, 0, 0.5, 1)
-                
-                local element = "ELEMENT " .. recruit:getElement()
-                love.graphics.print(element, 590 - self.font:getWidth(element) / 2, 360, 0, 0.5, 1)
+                love.graphics.printAlign(recruit:getDefense(), 590, 320, "right", 0, 0.5, 1)
+                love.graphics.printAlign("ELEMENT " .. recruit:getElement(), 590, 360, "right", 0, 0.5, 1)
             end
             
             Draw.setColor(1, 1, 1, 1)

--- a/src/utils/draw.lua
+++ b/src/utils/draw.lua
@@ -444,4 +444,10 @@ function Draw.rectangle(type, x, y, width, height)
     end
 end
 
+-- Same as love.graphics.print(), but has the align parameter after the y param
+-- Available align options: "left", "center" and "right"
+function Draw.printAlign(text, x, y, align, r, sx, sy, ox, oy, kx, ky)
+    love.graphics.print(text, x - ((align == "center" or align == "right") and love.graphics.getFont():getWidth(text) or 0) / (align == "center" and 2 or 1) * ((align == "center" or align == "right") and sx or 1), y, r, sx, sy, ox, oy, kx, ky)
+end
+
 return Draw

--- a/src/utils/draw.lua
+++ b/src/utils/draw.lua
@@ -447,7 +447,11 @@ end
 -- Same as love.graphics.print(), but has the align parameter after the y param
 -- Available align options: "left", "center" and "right"
 function Draw.printAlign(text, x, y, align, r, sx, sy, ox, oy, kx, ky)
-    love.graphics.print(text, x - ((align == "center" or align == "right") and love.graphics.getFont():getWidth(text) or 0) / (align == "center" and 2 or 1) * ((align == "center" or align == "right") and sx or 1), y, r, sx, sy, ox, oy, kx, ky)
+    local new_line_space = 0
+    for line in string.gmatch(text, "([^\n]+)") do
+        love.graphics.print(line, x - ((align == "center" or align == "right") and love.graphics.getFont():getWidth(line) or 0) / (align == "center" and 2 or 1) * ((align == "center" or align == "right") and sx or 1), y + new_line_space, r, sx, sy, ox, oy, kx, ky)
+        new_line_space = new_line_space + love.graphics.getFont():getHeight()
+    end
 end
 
 return Draw

--- a/src/utils/graphics.lua
+++ b/src/utils/graphics.lua
@@ -121,3 +121,7 @@ function graphics.translate(dx, dy)
     transform:translate(dx, dy)
     old_replaceTransform(transform)
 end
+
+function graphics.printAlign(text, x, y, align, r, sx, sy, ox, oy, kx, ky)
+    love.graphics.print(text, x - ((align == "center" or align == "right") and love.graphics.getFont():getWidth(text) or 0) / (align == "center" and 2 or 1) * ((align == "center" or align == "right") and sx or 1), y, r, sx, sy, ox, oy, kx, ky)
+end

--- a/src/utils/graphics.lua
+++ b/src/utils/graphics.lua
@@ -121,7 +121,3 @@ function graphics.translate(dx, dy)
     transform:translate(dx, dy)
     old_replaceTransform(transform)
 end
-
-function graphics.printAlign(text, x, y, align, r, sx, sy, ox, oy, kx, ky)
-    love.graphics.print(text, x - ((align == "center" or align == "right") and love.graphics.getFont():getWidth(text) or 0) / (align == "center" and 2 or 1) * ((align == "center" or align == "right") and sx or 1), y, r, sx, sy, ox, oy, kx, ky)
-end


### PR DESCRIPTION
Unlike love.graphics.printf(), this won't wrap the text, only allow aligning using the standard love.graphics.print().
Applied to the recruit menu.