### PR TITLE
Improved nothing warn condition

### DIFF
--- a/src/engine/game/game.lua
+++ b/src/engine/game/game.lua
@@ -402,10 +402,8 @@ function Game:load(data, index, fade)
     if self.is_new_file then
         if Kristal.getModOption("encounter") then
             self:encounter(Kristal.getModOption("encounter"), false)
-            self.nothing_warn = false
         elseif Kristal.getModOption("shop") then
             self:enterShop(Kristal.getModOption("shop"), {menu = true})
-            self.nothing_warn = false
         end
     end
 end
@@ -881,6 +879,8 @@ function Game:update()
         else
             Kristal.returnToMenu()
         end
+    else
+        self.nothing_warn = false
     end
 
     Kristal.callEvent(KRISTAL_EVENT.postUpdate, DT)


### PR DESCRIPTION
If a battle was started from the mod.lua instead of the mod.json, the warning won't appear after the battle ends