### PR TITLE
Fixed a crash that occurs when a saved party member that is in the party no longer exist

### DIFF
--- a/src/engine/game/game.lua
+++ b/src/engine/game/game.lua
@@ -275,8 +275,11 @@ function Game:load(data, index, fade)
     self.party = {}
     for _,id in ipairs(data.party or Kristal.getModOption("party") or {"kris"}) do
         local ally = self:getPartyMember(id)
-        assert(ally, string.format("Attempted to add non-existent member \"%s\" to the party", id))
-        table.insert(self.party, ally)
+        if ally then
+            table.insert(self.party, ally)
+        else
+            Kristal.Console:error(string.format("Could not load party member \"%s\"", id))
+        end
     end
     
     self:initRecruits()

--- a/src/engine/game/game.lua
+++ b/src/engine/game/game.lua
@@ -278,7 +278,7 @@ function Game:load(data, index, fade)
         if ally then
             table.insert(self.party, ally)
         else
-            Kristal.Console:error(string.format("Could not load party member \"%s\"", id))
+            Kristal.Console:error("Could not load party member \"" ..id.."\"")
         end
     end
     


### PR DESCRIPTION
Instead of crashing, it will print an error message in both the Love2D console and the in-game console, similar to when an item doesn't exist anymore.