### PR TITLE
Ball of junk accuracy (+ shadow crystal in events table)

### DIFF
--- a/data/items/key/shadowcrystal.lua
+++ b/data/items/key/shadowcrystal.lua
@@ -60,7 +60,7 @@ function item:getDescription()
 end
 
 function item:onWorldUse()
-    if Kristal.callEvent("onShadowCrystal", self, false) then
+    if Kristal.callEvent(KRISTAL_EVENT.onShadowCrystal, self, false) then
         return
     elseif not self:getFlag("used_none") then
         self:setFlag("used_none", true)

--- a/data/items/light/ball_of_junk.lua
+++ b/data/items/light/ball_of_junk.lua
@@ -63,6 +63,33 @@ function item:onToss()
     return false
 end
 
+function Item:onCheck()
+    Game.world:startCutscene(function(cutscene)
+        cutscene:text("* \""..self:getName().."\" - "..self:getCheck())
+
+        local comment
+
+        if self.inventory:hasItem("dark_candy") then
+            comment = "* It smells like scratch'n'sniff marshmallow stickers."
+        end
+
+        comment = Kristal.callEvent(KRISTAL_EVENT.onJunkCheck, self, comment) or comment
+
+        if comment then
+            cutscene:text(comment)
+        end
+    end)
+end
+
+function item:getCheck()
+    local check = self.check
+    if Game.chapter == 1 then
+        check = "A small ball\nof accumulated things."
+    end
+
+    return check
+end
+
 function item:convertToDark(inventory)
     for k,storage in pairs(self.inventory.storages) do
         for i = 1, storage.max do

--- a/data/items/light/glass.lua
+++ b/data/items/light/glass.lua
@@ -21,7 +21,7 @@ function item:init()
 end
 
 function item:onWorldUse()
-    if Kristal.callEvent("onShadowCrystal", self, true) then
+    if Kristal.callEvent(KRISTAL_EVENT.onShadowCrystal, self, true) then
         return
     elseif not self:getFlag("used_lw_no_party") and #Game.party == 1 and #Game.temp_followers == 0 then
         self:setFlag("used_lw_no_party", true)

--- a/mods/_testmod/mod.lua
+++ b/mods/_testmod/mod.lua
@@ -168,6 +168,10 @@ function Mod:onShadowCrystal(item, light)
     end
 end
 
+function Mod:onJunkCheck(item, comment)
+    return item.inventory:hasItem("dumburger") and "* It has a faint fragrance of utter stupidity." or comment
+end
+
 function Mod:getActionButtons(battler, buttons)
     if self.dog_activated then
         table.insert(buttons, DogButton())

--- a/src/engine/vars.lua
+++ b/src/engine/vars.lua
@@ -176,6 +176,7 @@ KRISTAL_EVENT = {
 
     --item events--
     onJunkCheck = "onJunkCheck", -- intercept ball of junk additional check text / at: item:onCheck() (light/ball_of_junk.lua) / passes: Item:item, nil|string:comment / returns: nil|string
+    onShadowCrystal = "onShadowCrystal", -- overrides text when shadow crystal or glass is used / at: item:onWorldUse() (light/glass.lua and key/shadowcrystal.lua) / passes: Item:item, bool:light / returns: nil|bool
 
     --menu events--
     createMenu = "createMenu", -- returns optional custom overworld menu / at: World:createMenu() / passes: NONE / returns: nil|Object

--- a/src/engine/vars.lua
+++ b/src/engine/vars.lua
@@ -174,6 +174,9 @@ KRISTAL_EVENT = {
     onConvertToDark = "onConvertToDark", -- dark world inventory converted to light world inventory / at: DarkInventory:convertToLight() / passes: LightInventory:new_inventory / returns: NONE
     onConvertToLight = "onConvertToLight", -- light world inventory converted to dark world inventory / at: LightInventory:convertToDark() / passes: DarkInventory:new_inventory / returns: NONE
 
+    --item events--
+    onJunkCheck = "onJunkCheck", -- intercept ball of junk additional check text / at: item:onCheck() (light/ball_of_junk.lua) / passes: Item:item, nil|string:comment / returns: nil|string
+
     --menu events--
     createMenu = "createMenu", -- returns optional custom overworld menu / at: World:createMenu() / passes: NONE / returns: nil|Object
     getDarkMenuButtons = "getDarkMenuButtons", -- optional creation of buttons for custom dark world menu / at: DarkMenu:init() / passes: table:buttons, DarkMenu:self / returns: nil|table


### PR DESCRIPTION
The ball of junk has some text that is not present in kristal - namely a shorter chapter 1 description and a bonus line when Dark Candy is present in the dark inventory. For the latter the `onJunkCheck` event has been added (similar to `onShadowCrystal`) so mod authors can extend the feature to other items. `onShadowCrystal` also now appears in the KRISTAL_EVENTS global table like all other events.