### PR TITLE
Battle, World, and Legend Cutscene documentation

### DIFF
--- a/src/engine/camera.lua
+++ b/src/engine/camera.lua
@@ -238,9 +238,9 @@ function Camera:approachDirect(x, y, amount)
     self:keepInBounds()
 end
 
----@param x number
----@param y number
----@param friction number
+---@param x? number
+---@param y? number
+---@param friction? number
 function Camera:shake(x, y, friction)
     self.shake_x = x or 4
     self.shake_y = y or x or 4

--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -1687,6 +1687,10 @@ function Battle:checkSolidCollision(collider)
     return false
 end
 
+--- Shakes the camera by the specified `x`, `y`.
+---@param x?        number      The amount of shake in the `x` direction. (Defaults to `4`)
+---@param y?        number      The amount of shake in the `y` direction. (Defaults to `4`)
+---@param friction? number      The amount that the shake should decrease by, per frame at 30FPS. (Defaults to `1`)
 function Battle:shakeCamera(x, y, friction)
     self.camera:shake(x, y, friction)
 end

--- a/src/engine/game/battle/battlecutscene.lua
+++ b/src/engine/game/battle/battlecutscene.lua
@@ -121,7 +121,7 @@ end
 --- The change lasts until the end of the cutscene or until the sprite is changed again.
 ---@param chara     string|Battler  The character to change the sprite of. Accepts either a Battler instance or an id to search for.
 ---@param sprite    string          The name of the sprite to be set.
----@param speed?    number          The number of seconds between frames for the sprite, if it has multiple frames. (Defaults to 1/30)
+---@param speed?    number          The time, in seconds, between frames for the sprite, if it has multiple frames. (Defaults to 1/30)
 function BattleCutscene:setSprite(chara, sprite, speed)
     if type(chara) == "string" then
         chara = self:getCharacter(chara)

--- a/src/engine/game/battle/battlecutscene.lua
+++ b/src/engine/game/battle/battlecutscene.lua
@@ -138,7 +138,7 @@ end
 --- The change lasts until the end of the cutscene or until the animation is changed again.
 ---@param chara string|Battler  The character to change the sprite of. Accepts either a Battler instance or an id to search for.
 ---@param anim  string          The name of the animation to be set.
----@return function finished A function that returns `true` once the animation has finished.
+---@return fun() : boolean finished A function that returns `true` once the animation has finished.
 function BattleCutscene:setAnimation(chara, anim)
     if type(chara) == "string" then
         chara = self:getCharacter(chara)
@@ -155,7 +155,7 @@ end
 ---@param x         number          The new x-coordinate to approach.
 ---@param y         number          The new y-coordinate to approach.
 ---@param speed?    number          The amount the character's `x` and `y` should approach their new position by every frame, in pixels per frame at 30FPS. (Defaults to `4`)
----@return function finished A function that returns `true` once the movement has finished.
+---@return fun() : boolean finished A function that returns `true` once the movement has finished.
 ---@deprecated use :slideToSpeed() instead.
 function BattleCutscene:moveTo(chara, x, y, speed)
     if type(chara) == "string" then
@@ -176,7 +176,7 @@ end
 ---@param y     number          The new y-coordinate to approach.
 ---@param time? number          The amount of time, in seconds, that the slide should take. (Defaults to 1 second)
 ---@param ease? string          The ease type to use when moving position. (Defaults to "linear")
----@return function finished A function that returns `true` once the movement is finished.
+---@return fun() : boolean finished A function that returns `true` once the movement is finished.
 function BattleCutscene:slideTo(obj, x, y, time, ease)
     if type(obj) == "string" then
         obj = self:getCharacter(obj)
@@ -194,7 +194,7 @@ end
 ---@param x         number The new x-coordinate to approach.
 ---@param y         number The new y-coordinate to approach.
 ---@param speed?    number The amount the character's `x` and `y` should approach their new position by every frame, in pixels per frame at 30FPS. (Defaults to `4`)
----@return function finished A function that returns `true` once the movement has finished.
+---@return fun() : boolean finished A function that returns `true` once the movement has finished.
 function BattleCutscene:slideToSpeed(obj, x, y, speed)
     if type(obj) == "string" then
         obj = self:getCharacter(obj)
@@ -213,7 +213,7 @@ end
 ---@param y?        number          The amount of shake in the `y` direction. (Defaults to `0`)
 ---@param friction? number          The amount that the shake should decrease by, per frame at 30FPS. (Defaults to `1`)
 ---@param delay?    number          The time it takes for the object to invert its shake direction, in seconds. (Defaults to `1/30`)
----@return function finished A function that returns `true` once the shake value has returned to 0.
+---@return fun() : boolean finished A function that returns `true` once the shake value has returned to 0.
 function BattleCutscene:shakeCharacter(chara, x, y, friction, delay)
     if type(chara) == "string" then
         chara = self:getCharacter(chara)
@@ -228,7 +228,7 @@ local function cameraShakeCheck() return Game.battle.camera.shake_x == 0 and Gam
 ---@param x?        number      The amount of shake in the `x` direction. (Defaults to `4`)
 ---@param y?        number      The amount of shake in the `y` direction. (Defaults to `4`)
 ---@param friction? number      The amount that the shake should decrease by, per frame at 30FPS. (Defaults to `1`)
----@return function finished    A function that returns `true` once the shake value has returned to `0`.
+---@return fun() : boolean finished    A function that returns `true` once the shake value has returned to `0`.
 function BattleCutscene:shakeCamera(x, y, friction)
     Game.battle:shakeCamera(x, y, friction)
     return cameraShakeCheck
@@ -238,7 +238,8 @@ end
 ---@param chara     string|Battler  The character being shaken. Accepts either a Battler instance or an id to search for.
 ---@param ...       unknown         Arguments to be passed to Battler:alert().
 ---@return Sprite   alert_icon      The result alert icon created above the character's head.
----@return function finished        A function that returns `true` once the alert icon has disappeared.
+---@return fun() : boolean finished        A function that returns `true` once the alert icon has disappeared. \
+---@see Battler - Battler:alert() for details on the arguments to pass to this function.
 function BattleCutscene:alert(chara, ...)
     if type(chara) == "string" then
         chara = self:getCharacter(chara)
@@ -254,7 +255,7 @@ end
 ---| "alpha"    # The alpha to start at (Defaults to `0`)
 ---| "blocky"   # Whether to do a rough, 'blocky' fade. (Defaults to `false`)
 ---| "music"    # The speed to fade the music at, or whether to fade it at all (Defaults to fade speed)
----@return function finished    A function that returns true once the fade has finished.
+---@return fun() : boolean finished    A function that returns true once the fade has finished.
 function BattleCutscene:fadeOut(speed, options)
     options = options or {}
 
@@ -278,7 +279,7 @@ end
 ---| "alpha"    # The alpha to start at (Defaults to `1`)
 ---| "blocky"   # Whether to do a rough, 'blocky' fade. (Defaults to `false`)
 ---| "music"    # The speed to fade the music at, or whether to fade it at all (Defaults to fade speed)
----@return function finished    A function that returns true once the fade has finished.
+---@return fun() : boolean finished    A function that returns true once the fade has finished.
 function BattleCutscene:fadeIn(speed, options)
     options = options or {}
 
@@ -321,7 +322,7 @@ local function waitForEncounterText() return Game.battle.battle_ui.encounter_tex
 ---|"advance"   # When `false`, the player cannot advance the textbox, and the cutscene will no longer suspend itself on the dialogue by default.
 ---|"auto"      # When `true`, the text will auto-advance after the last character has been typed.
 ---|"wait"      # Whether the cutscene should automatically suspend itself until the textbox advances. (Defaults to `true`, unless `advance` is false.)
----@return function finished If wait is not set to `true`, a function that returns `true` when the textbox has been advanced.
+---@return fun() finished If wait is not set to `true`, a function that returns `true` when the textbox has been advanced.
 function BattleCutscene:text(text, portrait, actor, options)
     if type(actor) == "table" then
         options = actor

--- a/src/engine/game/battle/battlecutscene.lua
+++ b/src/engine/game/battle/battlecutscene.lua
@@ -328,10 +328,12 @@ local function waitForEncounterText() return Game.battle.battle_ui.encounter_tex
 function BattleCutscene:text(text, portrait, actor, options)
     if type(actor) == "table" then
         options = actor
+        ---@diagnostic disable-next-line: cast-local-type
         actor = nil
     end
     if type(portrait) == "table" then
         options = portrait
+        ---@diagnostic disable-next-line: cast-local-type
         portrait = nil
     end
 

--- a/src/engine/game/battle/battlecutscene.lua
+++ b/src/engine/game/battle/battlecutscene.lua
@@ -1,3 +1,6 @@
+--- The cutscene class for cutscenes running in battles. \
+--- Cutscenes inside of `scripts/battle/cutscenes/` will receive BattleCutscene as their first argument.
+---
 ---@class BattleCutscene : Cutscene
 ---@overload fun(...) : BattleCutscene
 local BattleCutscene, super = Class(Cutscene)
@@ -64,6 +67,9 @@ function BattleCutscene:onEnd()
     end
 end
 
+--- Gets the first instance of a specific party or enemy character in the current battle.
+---@param id string The character id to search for.
+---@return PartyBattler|EnemyBattler|nil battler The PartyBattler/EnemyBattler instance of the character if they exist, otherwise `nil`.
 function BattleCutscene:getCharacter(id)
     for _,battler in ipairs(Game.battle.party) do
         if battler.chara.id == id then
@@ -77,6 +83,9 @@ function BattleCutscene:getCharacter(id)
     end
 end
 
+--- Gets all enemies with the specified id in the current battle.
+---@param id string The enemy id to search for.
+---@return table enemies A table containing all matched EnemyBattler instances.
 function BattleCutscene:getEnemies(id)
     local result = {}
     for _,battler in ipairs(Game.battle.enemies) do
@@ -87,14 +96,20 @@ function BattleCutscene:getEnemies(id)
     return result
 end
 
+--- Gets the character that is performing the current action.
+---@return PartyBattler battler The PartyBattler performing the current action.
 function BattleCutscene:getUser()
     return Game.battle.party[Game.battle:getCurrentAction().character_id]
 end
 
+--- Gets the character being targetted of the current action.
+---@return Battler target The target Battler of the current action.
 function BattleCutscene:getTarget()
     return Game.battle:getCurrentAction().target
 end
 
+--- Resets the sprites of characters who have had their sprites changed in this cutscene. \
+--- Called in BattleCutscene:onEnd() automatically.
 function BattleCutscene:resetSprites()
     for battler,_ in pairs(self.changed_sprite) do
         battler:toggleOverlay(false)
@@ -102,6 +117,11 @@ function BattleCutscene:resetSprites()
     self.changed_sprite = {}
 end
 
+--- Sets the sprite of a particular character. \
+--- The change lasts until the end of the cutscene or until the sprite is changed again.
+---@param chara     string|Battler  The character to change the sprite of. Accepts either a Battler instance or an id to search for.
+---@param sprite    string          The name of the sprite to be set.
+---@param speed?    number          The number of seconds between frames for the sprite, if it has multiple frames. (Defaults to 1/30)
 function BattleCutscene:setSprite(chara, sprite, speed)
     if type(chara) == "string" then
         chara = self:getCharacter(chara)
@@ -114,6 +134,11 @@ function BattleCutscene:setSprite(chara, sprite, speed)
     self.changed_sprite[chara] = true
 end
 
+--- Sets the animation of a particular character. \
+--- The change lasts until the end of the cutscene or until the animation is changed again.
+---@param chara string|Battler  The character to change the sprite of. Accepts either a Battler instance or an id to search for.
+---@param anim  string          The name of the animation to be set.
+---@return function finished A function that returns `true` once the animation has finished.
 function BattleCutscene:setAnimation(chara, anim)
     if type(chara) == "string" then
         chara = self:getCharacter(chara)
@@ -125,6 +150,13 @@ function BattleCutscene:setAnimation(chara, anim)
     return function() return done end
 end
 
+--- *(Deprecated)* Linearly moves a character to a new position (`x`, `y`) over time at a rate of `speed` pixels per frame.
+---@param chara     string|Battler  The character being moved. Accepts either a Battler instance or an id to search for.
+---@param x         number          The new x-coordinate to approach.
+---@param y         number          The new y-coordinate to approach.
+---@param speed?    number          The amount the character's `x` and `y` should approach their new position by every frame, in pixels per frame at 30FPS. (Defaults to `4`)
+---@return function finished A function that returns `true` once the movement has finished.
+---@deprecated use :slideToSpeed() instead.
 function BattleCutscene:moveTo(chara, x, y, speed)
     if type(chara) == "string" then
         chara = self:getCharacter(chara)
@@ -137,6 +169,14 @@ function BattleCutscene:moveTo(chara, x, y, speed)
     return _true
 end
 
+--- Moves a character to a new position (`x`, `y`) over `time` seconds. \ 
+--- Supports easing.
+---@param obj   string|Battler  The character being moved. Accepts either a Battler instance or an id to search for.
+---@param x     number          The new x-coordinate to approach.
+---@param y     number          The new y-coordinate to approach.
+---@param time? number          The amount of time, in seconds, that the slide should take. (Defaults to 1 second)
+---@param ease? string          The ease type to use when moving position. (Defaults to "linear")
+---@return function finished A function that returns `true` once the movement is finished.
 function BattleCutscene:slideTo(obj, x, y, time, ease)
     if type(obj) == "string" then
         obj = self:getCharacter(obj)
@@ -149,6 +189,12 @@ function BattleCutscene:slideTo(obj, x, y, time, ease)
     end
 end
 
+--- Linearly moves a character to a new position (`x`, `y`) over time at a rate of `speed` pixels per frame.
+---@param obj       string|Battler The character being moved. Accepts either a Battler instance or an id to search for.
+---@param x         number The new x-coordinate to approach.
+---@param y         number The new y-coordinate to approach.
+---@param speed?    number The amount the character's `x` and `y` should approach their new position by every frame, in pixels per frame at 30FPS. (Defaults to `4`)
+---@return function finished A function that returns `true` once the movement has finished.
 function BattleCutscene:slideToSpeed(obj, x, y, speed)
     if type(obj) == "string" then
         obj = self:getCharacter(obj)
@@ -161,6 +207,13 @@ function BattleCutscene:slideToSpeed(obj, x, y, speed)
     end
 end
 
+--- Shakes a character by the specified `x`, `y`.
+---@param chara     string|Battler  The character being shaken. Accepts either a Battler instance or an id to search for.
+---@param x?        number          The amount of shake in the `x` direction. (Defaults to `4`)
+---@param y?        number          The amount of shake in the `y` direction. (Defaults to `0`)
+---@param friction? number          The amount that the shake should decrease by, per frame at 30FPS. (Defaults to `1`)
+---@param delay?    number          The time it takes for the object to invert its shake direction, in seconds. (Defaults to `1/30`)
+---@return function finished A function that returns `true` once the shake value has returned to 0.
 function BattleCutscene:shakeCharacter(chara, x, y, friction, delay)
     if type(chara) == "string" then
         chara = self:getCharacter(chara)
@@ -171,11 +224,21 @@ function BattleCutscene:shakeCharacter(chara, x, y, friction, delay)
 end
 
 local function cameraShakeCheck() return Game.battle.camera.shake_x == 0 and Game.battle.camera.shake_y == 0 end
+--- Shakes the camera by the specified `x`, `y`.
+---@param x?        number      The amount of shake in the `x` direction. (Defaults to `4`)
+---@param y?        number      The amount of shake in the `y` direction. (Defaults to `4`)
+---@param friction? number      The amount that the shake should decrease by, per frame at 30FPS. (Defaults to `1`)
+---@return function finished    A function that returns `true` once the shake value has returned to `0`.
 function BattleCutscene:shakeCamera(x, y, friction)
     Game.battle:shakeCamera(x, y, friction)
     return cameraShakeCheck
 end
 
+--- Creates an alert bubble above a character.
+---@param chara     string|Battler  The character being shaken. Accepts either a Battler instance or an id to search for.
+---@param ...       unknown         Arguments to be passed to Battler:alert().
+---@return Sprite   alert_icon      The result alert icon created above the character's head.
+---@return function finished        A function that returns `true` once the alert icon has disappeared.
 function BattleCutscene:alert(chara, ...)
     if type(chara) == "string" then
         chara = self:getCharacter(chara)
@@ -184,6 +247,14 @@ function BattleCutscene:alert(chara, ...)
     return chara:alert(...), waitForAlertRemoval
 end
 
+--- Fades the screen and music out.
+---@param speed?    number       The speed to fade out at, in seconds. (Defaults to `0.25`)
+---@param options?  table        A table defining additional properties to control the fade.
+---| "color"    # The color that should be faded to (Defaults to `COLORS.black`)
+---| "alpha"    # The alpha to start at (Defaults to `0`)
+---| "blocky"   # Whether to do a rough, 'blocky' fade. (Defaults to `false`)
+---| "music"    # The speed to fade the music at, or whether to fade it at all (Defaults to fade speed)
+---@return function finished    A function that returns true once the fade has finished.
 function BattleCutscene:fadeOut(speed, options)
     options = options or {}
 
@@ -200,6 +271,14 @@ function BattleCutscene:fadeOut(speed, options)
     return function() return fade_done end
 end
 
+--- Fades the screen and music back in after a fade out.
+---@param speed?    number  The speed to fade in at, in seconds (Defaults to last fadeOut's speed.)
+---@param options?  table   A table defining additional properties to control the fade.
+---| "color"    # The color that should be faded to (Defaults to last fadeOut's color)
+---| "alpha"    # The alpha to start at (Defaults to `1`)
+---| "blocky"   # Whether to do a rough, 'blocky' fade. (Defaults to `false`)
+---| "music"    # The speed to fade the music at, or whether to fade it at all (Defaults to fade speed)
+---@return function finished    A function that returns true once the fade has finished.
 function BattleCutscene:fadeIn(speed, options)
     options = options or {}
 
@@ -216,6 +295,8 @@ function BattleCutscene:fadeIn(speed, options)
     return function() return fade_done end
 end
 
+--- Sets the active speaker for the encountertext box.
+---@param actor PartyBattler|EnemyBattler|Actor|nil The character or actor to set as the speaker. `nil` resets the speaker to nothing.
 function BattleCutscene:setSpeaker(actor)
     if isClass(actor) and (actor:includes(PartyBattler) or actor:includes(EnemyBattler)) then
         actor = actor.actor
@@ -224,6 +305,23 @@ function BattleCutscene:setSpeaker(actor)
 end
 
 local function waitForEncounterText() return Game.battle.battle_ui.encounter_text.text.text == "" end
+--- Types text on the encounter text box, and suspends the cutscene until the player progresses the dialogue. \
+--- When passing arguments to this function, the options table can be passed as the second or third argument to forgo specifying `portrait` or `actor`.
+---@param text      string  The text to be typed.
+---@param portrait? string  The character portrait to be used.
+---@param actor?    Actor   The actor to use for voice bytes and dialogue portraits, overriding the active speaker.
+---@param options?  table   A table defining additional properties to control the text.
+---|"x"         # The x-offset of the dialgoue portrait.
+---|"y"         # The y-offset of the dialogue portrait.
+---|"reactions" # A table of tables that define "reaction" dialogues. Each table defines the dialogue, x and y position of the face, actor and face sprite, in that order. x and y can be strings as well, referring to existing positions; x can be left, leftmid, mid, middle, rightmid, or right, and y can be top, mid, middle, bottommid, and bottom. Must be used in combination with a react text command.
+---|"functions" # A table defining additional functions that can be used in the text with the `func` text command. Each key, value pair will form the id to use with `func` and the function to be called, respectively.
+---|"font"      # The font to be used for this text. Can optionally be defined as a table {font, size} to also set the text size.
+---|"align"     # Sets the alignment of the text.
+---|"skip"      # If false, the player will be unable to skip the textbox with the cancel key.
+---|"advance"   # When `false`, the player cannot advance the textbox, and the cutscene will no longer suspend itself on the dialogue by default.
+---|"auto"      # When `true`, the text will auto-advance after the last character has been typed.
+---|"wait"      # Whether the cutscene should automatically suspend itself until the textbox advances. (Defaults to `true`, unless `advance` is false.)
+---@return function finished If wait is not set to `true`, a function that returns `true` when the textbox has been advanced.
 function BattleCutscene:text(text, portrait, actor, options)
     if type(actor) == "table" then
         options = actor
@@ -289,6 +387,19 @@ function BattleCutscene:text(text, portrait, actor, options)
     end
 end
 
+--- Creates a text bubble for one or more battlers.
+---@param battlers  string|Battler  A battler id, or a Battler instance. If multiple battlers share the same id, specifying one will create a bubble for each of them.
+---@param text      string          The text that will appear in the speech bubble.
+---@param options?  table           A table defining additional properties to control the text.
+---|"wait"          # Whether the cutscene should automatically suspend itself until the bubbles have finished. (Defaults to `true`)
+---|"x"             # The x-offset of the speech bubble. (Defaults to `0`)
+---|"y"             # The y-offset of the speech bubble. (Defaults to `0`)
+---|"advance"       # Whether the bubble can be manually advanced by the player. (Defaults to `true`)
+---|"auto"          # Whether the bubble will auto-advance after it has typed the last character. (Defaults to `false`)
+---|"after"         # A callback to add to the bubble, that will be run when it finishes.
+---|"line_callback" # Sets the line_callback of the text.
+---@return any      finished        If the cutscene is not automatically waiting, a boolean that reflects whether all the dialogue bubbles have finished.
+---@return table?   bubbles         A table of all bubbles created by this function call.
 function BattleCutscene:battlerText(battlers, text, options)
     options = options or {}
     if type(battlers) == "string" then
@@ -348,6 +459,14 @@ function BattleCutscene:battlerText(battlers, text, options)
 end
 
 local function waitForChoicer() return Game.battle.battle_ui.choice_box.done, Game.battle.battle_ui.choice_box.selected_choice end
+--- Creates a choicer with the given set of choices for the player to select from.
+---@param choices  table A table of strings specifying the choices the player can select. Maximum of four.
+---@param options? table A table defining additional properties to control the choicer.
+---|"color"     # The main color to set all the choices to, or a table of main colors to set for different choices. (Defaults to `COLORS.white`)
+---|"highlight" # The color to highlight the selected choice in, or a table of colors to highlight different choices in when selected. (Defaults to `COLORS.yellow`)
+---|"wait"      # Whether the cutscene should automatically suspend itself until the player makes their choice. (Defaults to `true`)
+---@return number|function selected The index of the selected item if the cutscene has been set to wait for the choicer, otherwise a boolean that states whether the player has made their choice.
+---@return Choicebox? choicer The choicebox object for this choicer. Only returned if wait is `false`. 
 function BattleCutscene:choicer(choices, options)
     options = options or {}
 
@@ -371,6 +490,7 @@ function BattleCutscene:choicer(choices, options)
     end
 end
 
+--- Clears the active choicebox and current encounter text, and removes all battler bubbles.
 function BattleCutscene:closeText()
     local choice_box = Game.battle.battle_ui.choice_box
     local text = Game.battle.battle_ui.encounter_text

--- a/src/engine/game/battle/battlecutscene.lua
+++ b/src/engine/game/battle/battlecutscene.lua
@@ -1,5 +1,5 @@
---- The cutscene class for cutscenes running in battles. \
---- Cutscenes inside of `scripts/battle/cutscenes/` will receive BattleCutscene as their first argument.
+--- The cutscene class for cutscenes running in battles, their scripts should be located in `scripts/battle/cutscenes/`. \
+--- These cutscene scripts will receive a BattleCutscene as their first argument.
 ---
 ---@class BattleCutscene : Cutscene
 ---@overload fun(...) : BattleCutscene
@@ -239,7 +239,7 @@ end
 ---@param ...       unknown         Arguments to be passed to Battler:alert().
 ---@return Sprite   alert_icon      The result alert icon created above the character's head.
 ---@return fun() : boolean finished        A function that returns `true` once the alert icon has disappeared. \
----@see Battler - Battler:alert() for details on the arguments to pass to this function.
+---@see Battler.alert for details on the arguments to pass to this function.
 function BattleCutscene:alert(chara, ...)
     if type(chara) == "string" then
         chara = self:getCharacter(chara)
@@ -308,9 +308,11 @@ end
 local function waitForEncounterText() return Game.battle.battle_ui.encounter_text.text.text == "" end
 --- Types text on the encounter text box, and suspends the cutscene until the player progresses the dialogue. \
 --- When passing arguments to this function, the options table can be passed as the second or third argument to forgo specifying `portrait` or `actor`.
+---@overload fun(self: BattleCutscene, text: string, options?: table): finished: fun(): boolean
+---@overload fun(self: BattleCutscene, text: string, portrait: string, options?: table): finished: fun(): boolean
 ---@param text      string  The text to be typed.
----@param portrait? string  The character portrait to be used.
----@param actor?    Actor   The actor to use for voice bytes and dialogue portraits, overriding the active speaker.
+---@param portrait  string  The character portrait to be used.
+---@param actor     Actor   The actor to use for voice bytes and dialogue portraits, overriding the active cutscene speaker.
 ---@param options?  table   A table defining additional properties to control the text.
 ---|"x"         # The x-offset of the dialgoue portrait.
 ---|"y"         # The y-offset of the dialogue portrait.
@@ -322,7 +324,7 @@ local function waitForEncounterText() return Game.battle.battle_ui.encounter_tex
 ---|"advance"   # When `false`, the player cannot advance the textbox, and the cutscene will no longer suspend itself on the dialogue by default.
 ---|"auto"      # When `true`, the text will auto-advance after the last character has been typed.
 ---|"wait"      # Whether the cutscene should automatically suspend itself until the textbox advances. (Defaults to `true`, unless `advance` is false.)
----@return fun() finished If wait is not set to `true`, a function that returns `true` when the textbox has been advanced.
+---@return fun() finished A function that returns `true` when the textbox has been advanced. (Only use if `options["wait"]` is set to `false`.)
 function BattleCutscene:text(text, portrait, actor, options)
     if type(actor) == "table" then
         options = actor
@@ -460,7 +462,7 @@ function BattleCutscene:battlerText(battlers, text, options)
 end
 
 local function waitForChoicer() return Game.battle.battle_ui.choice_box.done, Game.battle.battle_ui.choice_box.selected_choice end
---- Creates a choicer with the given set of choices for the player to select from.
+--- Creates a choicer with the choices specified in `choices` for the player to select from.
 ---@param choices  table A table of strings specifying the choices the player can select. Maximum of four.
 ---@param options? table A table defining additional properties to control the choicer.
 ---|"color"     # The main color to set all the choices to, or a table of main colors to set for different choices. (Defaults to `COLORS.white`)

--- a/src/engine/game/battle/battler.lua
+++ b/src/engine/game/battle/battler.lua
@@ -69,6 +69,16 @@ function Battler:flash(sprite, offset_x, offset_y, layer)
     return sprite_to_use:flash(offset_x, offset_y, layer)
 end
 
+--- Creates an alert bubble (tiny !) above this battler.
+---@param duration?     number  The number of frames to show the bubble for. (Defaults to `20`)
+---@param options?      table   A table defining additional properties to control the bubble.
+---|"play_sound"    # Whether the alert sound will be played. (Defaults to `true`)
+---|"sprite"        # The sprite to use for the alert bubble. (Defaults to `"effects/alert"`)
+---|"offset_x"      # The x-offset of the icon.
+---|"offset_y"      # The y-offset of the icon.
+---|"layer"         # The layer to put the icon on. (Defaults to `100`)
+---|"callback"      # A callback that is run when the alert finishes.
+---@return Sprite
 function Battler:alert(duration, options)
     options = options or {}
     if options["play_sound"] == nil or options["play_sound"] then

--- a/src/engine/game/common/actorsprite.lua
+++ b/src/engine/game/common/actorsprite.lua
@@ -50,6 +50,8 @@ function ActorSprite:init(actor)
     self.last_flippable = actor:getFlipDirection(self)
 end
 
+--- Resets this sprite to the default animation or sprite.
+---@param ignore_actor_callback? boolean When set to `true`, will not call the actor's `preResetSprite()` function.
 function ActorSprite:resetSprite(ignore_actor_callback)
     if not ignore_actor_callback and self.actor:preResetSprite(self) then
         return

--- a/src/engine/game/common/choicebox.lua
+++ b/src/engine/game/common/choicebox.lua
@@ -119,10 +119,15 @@ function Choicebox:clearChoices()
     self.current_choice = 0
 end
 
+--- Adds a new choice to the choicebox.
+---@param name string The name of the new choice that will be shown for the selection.
 function Choicebox:addChoice(name)
     table.insert(self.choices, name)
 end
 
+--- Sets the main and hover colors for every choice in the choicebox.
+---@param main? table   The main color to set for all choices, or a table of main colors for each individual choice. (Defaults to `COLORS.white`)
+---@param hover? table  The hover color to set for all choices, or a table of hover colors for each individual choice. (Defaults to `COLORS.yellow`)
 function Choicebox:setColors(main, hover)
     main = main or {1,1,1}
     if type(main[1]) == "number" then

--- a/src/engine/game/common/cutscene.lua
+++ b/src/engine/game/common/cutscene.lua
@@ -64,7 +64,7 @@ end
 --- Adds a new callback to this cutscene.
 ---@param func      function    The callback function to set or append to this cutscene.
 ---@param replace   boolean     Whether or not to overwrite all previously defined callbacks on this function.
----@return Cutscene self
+---@return Cutscene? self
 function Cutscene:after(func, replace)
     if self.ended then
         if func and (replace or not self.replaced_callback) then
@@ -162,6 +162,8 @@ function Cutscene:wait(seconds)
     return coroutine.yield()
 end
 
+--- Indefinitely pausees the cutscene.
+---@return any
 function Cutscene:pause()
     self.paused = true
     return coroutine.yield()
@@ -176,6 +178,8 @@ function Cutscene:tryResume()
     return false
 end
 
+--- Resumes the cutscene if it had been previously paused.
+---@param ... unknown
 function Cutscene:resume(...)
     self.paused = false
     self.wait_func = nil

--- a/src/engine/game/common/cutscene.lua
+++ b/src/engine/game/common/cutscene.lua
@@ -1,5 +1,5 @@
 --- The underlying class for cutscene types in Kristal. \
---- See WorldCutscene or BattleCutscene for most available functions when creating cutscenes.
+--- See WorldCutscene, BattleCutscene, or LegendCutscene for the available functions when creating the respective cutscene types.
 ---
 ---@class Cutscene : Class
 ---@overload fun(...) : Cutscene
@@ -61,6 +61,10 @@ function Cutscene:parseFromGetter(getter, cutscene, id, ...)
     end
 end
 
+--- Adds a new callback to this cutscene.
+---@param func      function    The callback function to set or append to this cutscene.
+---@param replace   boolean     Whether or not to overwrite all previously defined callbacks on this function.
+---@return Cutscene self
 function Cutscene:after(func, replace)
     if self.ended then
         if func and (replace or not self.replaced_callback) then
@@ -104,6 +108,8 @@ function Cutscene:canResume()
     return true
 end
 
+--- *(Called internally)* *(Override)* Checks whether the cutscene is currently in a state to be ended.
+---@return boolean can_end Whether the cutscene is able to be ended.
 function Cutscene:canEnd()
     return true
 end
@@ -136,6 +142,8 @@ function Cutscene:update()
     end
 end
 
+--- *(Called internally)* Internal callback for when cutscenes end. \
+--- Also responsible for calling user defined callbacks from Cutscene:after()
 function Cutscene:onEnd()
     if self.finished_callback then
         self:finished_callback()
@@ -183,6 +191,10 @@ function Cutscene:endCutscene()
     self:onEnd()
 end
 
+--- Starts executing a new cutscene script specified by `func`.
+---@param func function     The new cutscene script.
+---@param ... unknown       Additional arguments to pass to the new cutscene.
+---@return unknown
 function Cutscene:gotoCutscene(func, ...)
     if self.getter then
         local new_func, args = self:parseFromGetter(self.getter, func, ...)

--- a/src/engine/game/common/cutscene.lua
+++ b/src/engine/game/common/cutscene.lua
@@ -1,3 +1,6 @@
+--- The underlying class for cutscene types in Kristal. \
+--- See WorldCutscene or BattleCutscene for most available functions when creating cutscenes.
+---
 ---@class Cutscene : Class
 ---@overload fun(...) : Cutscene
 local Cutscene, super = Class()
@@ -139,6 +142,9 @@ function Cutscene:onEnd()
     end
 end
 
+--- Temporarily suspends execution of the cutscene script.
+---@param seconds? function|number When a `number`, waits this number of seconds before continuing. When a `function`, waits until this function returns `true`. (Defaults to 0)
+---@return any
 function Cutscene:wait(seconds)
     if type(seconds) == "function" then
         self.wait_func = seconds
@@ -171,6 +177,7 @@ function Cutscene:resume(...)
     end
 end
 
+--- Ends the cutscene.
 function Cutscene:endCutscene()
     self.ended = true
     self:onEnd()

--- a/src/engine/game/common/cutscene.lua
+++ b/src/engine/game/common/cutscene.lua
@@ -1,5 +1,7 @@
 --- The underlying class for cutscene types in Kristal. \
---- See WorldCutscene, BattleCutscene, or LegendCutscene for the available functions when creating the respective cutscene types.
+---@see WorldCutscene   # For functions specific to cutscene scripts that play in a world.
+---@see BattleCutscene  # For functions specific to cutscene scripts playing in a battle.
+---@see LegendCutscene  # For functions specific to legend cutscene scripts.
 ---
 ---@class Cutscene : Class
 ---@overload fun(...) : Cutscene
@@ -61,7 +63,7 @@ function Cutscene:parseFromGetter(getter, cutscene, id, ...)
     end
 end
 
---- Adds a new callback to this cutscene.
+--- Adds a new callback for the end of this cutscene.
 ---@param func      function    The callback function to set or append to this cutscene.
 ---@param replace   boolean     Whether or not to overwrite all previously defined callbacks on this function.
 ---@return Cutscene? self
@@ -90,6 +92,10 @@ function Cutscene:after(func, replace)
     return self
 end
 
+--- Adds a new during callback to this cutscene. \
+--- During callbacks run once every frame during cutscenes, and they can remove themselves from the cutscene by returning `false`.
+---@param func      fun() : boolean?    The function to be run.
+---@param replace   boolean             Whether the new callback should replace all currently active during callbacks.
 function Cutscene:during(func, replace)
     if self.ended then return end
     if replace then
@@ -98,6 +104,14 @@ function Cutscene:during(func, replace)
     table.insert(self.during_stack, func)
 end
 
+--- *(Called internally)* Checks whether the cutscene is ready to resume. 
+---@return boolean ready Whether the cutscene is ready to resume.
+---@return any a
+---@return any b
+---@return any c
+---@return any d
+---@return any e
+---@return any f
 function Cutscene:canResume()
     if self.wait_timer > 0 or self.paused then
         return false
@@ -108,12 +122,15 @@ function Cutscene:canResume()
     return true
 end
 
---- *(Called internally)* *(Override)* Checks whether the cutscene is currently in a state to be ended.
+--- *(Called internally)* *(Override)* Checks whether the cutscene is currently in a state suitable to be ended.
 ---@return boolean can_end Whether the cutscene is able to be ended.
 function Cutscene:canEnd()
     return true
 end
 
+--- *(Override)* Runs once every frame that the cutscene instance exists (including when suspended). \
+--- New cutscene types should always call `super.update(self)` if they override this function! \
+---@see Cutscene.during if you are looking to run code every frame in a cutscene script.
 function Cutscene:update()
     if self.ended then return end
 
@@ -151,8 +168,8 @@ function Cutscene:onEnd()
 end
 
 --- Temporarily suspends execution of the cutscene script.
----@param seconds? function|number When a `number`, waits this number of seconds before continuing. When a `function`, waits until this function returns `true`. (Defaults to 0)
----@return any
+---@param seconds? function|number When a `number`, waits this number of seconds before continuing. When a `function`, waits until this function returns `true`. (Defaults to `0`)
+---@return any ... Any values passed into the adjacent Cutscene:resume(...) call. 
 function Cutscene:wait(seconds)
     if type(seconds) == "function" then
         self.wait_func = seconds
@@ -169,6 +186,9 @@ function Cutscene:pause()
     return coroutine.yield()
 end
 
+--- *(Called internally)* Checks whether the cutscene is ready to be resumed, and resumes it if the check succeeds. \
+--- Any additional return values from `Cutscene:canResume()` are passed through into `Cutscene:resume(...)`.
+---@return boolean success Whether the cutscene successfully resumed.
 function Cutscene:tryResume()
     local result, a,b,c,d,e,f = self:canResume()
     if result then
@@ -179,7 +199,7 @@ function Cutscene:tryResume()
 end
 
 --- Resumes the cutscene if it had been previously paused.
----@param ... unknown
+---@param ... unknown Additional arguments that will be returned by the adjacent `Cutscene:wait()` call.
 function Cutscene:resume(...)
     self.paused = false
     self.wait_func = nil
@@ -208,6 +228,11 @@ function Cutscene:gotoCutscene(func, ...)
     end
 end
 
+--- Plays a sound.
+---@param sound     string
+---@param volume?   number
+---@param pitch?    number
+---@return function finished A function that returns `true` once the sound has stopped playing.
 function Cutscene:playSound(sound, volume, pitch)
     local src = Assets.playSound(sound, volume, pitch)
     return function()

--- a/src/engine/game/game.lua
+++ b/src/engine/game/game.lua
@@ -516,6 +516,14 @@ function Game:loadQuick(fade)
     self.quick_save = save
 end
 
+-- DOC Note: whats IS a context; I left it blank because its not relevant
+-- to the cutscene files being documented as i write this
+
+--- Starts a battle using the specified encounter file.
+---@param encounter     Encounter|string    The encounter id or instance to use for this battle.
+---@param transition?   boolean|string      Whether to start in the transition state (Defaults to `true`). As a string, represents the state to start the battle in.
+---@param enemy?        Character|table     An enemy instance or list of enemies as `Character`s in the world that will transition into the battle.
+---@param context       any
 function Game:encounter(encounter, transition, enemy, context)
     if transition == nil then transition = true end
 

--- a/src/engine/game/legend/legendcutscene.lua
+++ b/src/engine/game/legend/legendcutscene.lua
@@ -1,3 +1,18 @@
+--- A special cutscene class for Legend-style cutscenes. \
+--- Write an annotation here about how these cutscenes start!
+---
+---@class LegendCutscene : Cutscene
+---
+--- A table of preset positions for use with `LegendCutscene:text()`. \
+--- Available positions: `"far_left"`, `"far_right"`, `"left"`, `"top_left"`, \
+--- `"middle_bottom"`, `"left_bottom"`, `"far_left_bottom"`, `"text_human"`, \
+--- `"text_monster"`, `"text_prince"`.
+---@field text_positions table
+---
+--- The speed that newly created text will type at in the cutscene, in characters per frame.
+---@field speed number
+---
+---@overload fun(...) : LegendCutscene
 local LegendCutscene, super = Class(Cutscene, "LegendCutscene")
 
 function LegendCutscene:init(group, id, ...)
@@ -33,16 +48,24 @@ function LegendCutscene:onEnd()
     Game.legend.fader:fadeOut(function() Game.legend:onFinish() end, { speed = 2, music = true })
 end
 
+--- Removes all currently active text objects from the cutscene.
 function LegendCutscene:removeText()
     for i, v in ipairs(self.text_objects) do
         v:remove()
     end
 end
 
+--- Sets the typing speed of the legend text. \
+--- Default typing speed is `1`.
+---@param speed number  The speed, in characters typed per frame.
 function LegendCutscene:setSpeed(speed)
     self.speed = speed
 end
 
+--- Writes some text at the given coordinates on the screen.
+---@param text  string  The text to display.
+---@param pos   table   A table of the x and y coordinates to start writing the text at. See `LegendCutscene.text_positions` for a set of default text positions.
+---@return DialogueText dialogue
 function LegendCutscene:text(text, pos)
     local x, y = unpack(self.text_positions[pos])
     local dialogue = Game.legend:addChild(DialogueText(text, x, y, nil, nil, {style = "none"}))
@@ -56,14 +79,22 @@ function LegendCutscene:text(text, pos)
     return dialogue
 end
 
+--- Suspends the cutscene until the music reaches a certain runtime.
+---@param time number   The song runtime to wait until before resuming the cutscene, in seconds.
+---@return any
 function LegendCutscene:musicWait(time)
     return self:wait(function() return Game.legend.music:tell() >= time end)
 end
 
+--- Adds a new picture slide to the legend.
+---@param texture   string  The path to the texture for the new slide.
+---@return Sprite slide The sprite created for the new panel.
 function LegendCutscene:slide(texture)
     return Game.legend:addSlide(texture)
 end
 
+--- Starts fading out the currently visible slides.
+---@return nil
 function LegendCutscene:removeSlides()
     return Game.legend:removeSlides()
 end

--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -573,6 +573,12 @@ function World:spawnBullet(bullet, ...)
     return new_bullet
 end
 
+--- Spawns a new NPC object in the world.
+---@param actor         string|Actor    The actor to use for the new NPC, either an id string or an actor object.
+---@param x             number          The x-coordinate to place the NPC at.
+---@param y             number          The y-coordinate to place the NPC at.
+---@param properties    table           A table of additional properties for the new NPC. Supports all the same values as an `npc` map event.
+---@return NPC npc The newly created npc.
 function World:spawnNPC(actor, x, y, properties)
     return self:spawnObject(NPC(actor, x, y, properties))
 end
@@ -583,6 +589,10 @@ function World:spawnObject(obj, layer)
     return obj
 end
 
+--- Gets a specific character currently present in the world.
+---@param id        string  The actor id of the character to search for.
+---@param index?    number  The character's index, if they have multiple instances in the world. (Defaults to 1)
+---@return Character|nil chara The character instance, or `nil` if it was not found.
 function World:getCharacter(id, index)
     local party_member = Game:getPartyMember(id)
     local i = 0
@@ -624,18 +634,22 @@ function World:getEvents(name)
     return self.map:getEvents(name)
 end
 
+--- Disables following for all of the player's current followers.
 function World:detachFollowers()
     for _,follower in ipairs(self.followers) do
         follower.following = false
     end
 end
 
+--- Enables following for all of the player's current followers and causes them to walk to their positions.
+---@param return_speed number The walking speed of the followers while they return to the player.
 function World:attachFollowers(return_speed)
     for _,follower in ipairs(self.followers) do
         follower:updateIndex()
         follower:returnToFollowing(return_speed)
     end
 end
+--- Enables following for all of the player's current followers, and immediately teleports them to their positions.
 function World:attachFollowersImmediate()
     for _,follower in ipairs(self.followers) do
         follower.following = true

--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -729,6 +729,16 @@ function World:setupMap(map, ...)
     end
 end
 
+--- Loads into a new map file.
+---@overload fun(self: World, map: string, x: number, y: number, facing?: string, callback?: string, ...: any)
+---@overload fun(self: World, map: string, marker?: string, facing?: string, callback?: string, ...: any)
+---@param map       string      The name of the map file to load.
+---@param x         number      The x-coordinate the player will spawn at in the new map.
+---@param y         number      The y-coordinate the player will spawn at in the new map.
+---@param marker?   string      The name of the marker the player will spawn at in the new map. Defaults to `"spawn"`
+---@param facing?   string      The direction the party should be facing when they spawn in the new map.
+---@param callback? fun()       A callback to run once the map has finished loading (Post Map:onEnter())
+---@param ... unknown           Additional arguments that will be passed forward into Map:onEnter().
 function World:loadMap(...)
     local args = {...}
     -- x, y, facing, callback
@@ -862,6 +872,10 @@ function World:shopTransition(shop, options)
     end)
 end
 
+--- Loads a new map and starts the transition effects for world music, borders, and the screen as a whole.
+---@overload fun(self: World, map: string, ...: any)
+---@param ... any   Additional arguments that will be passed into World:loadMap()
+---@see World - World:loadMap() 
 function World:mapTransition(...)
     local args = {...}
     local map = args[1]

--- a/src/engine/game/world/character.lua
+++ b/src/engine/game/world/character.lua
@@ -99,6 +99,8 @@ function Character:setActor(actor)
     self:addChild(self.sprite)
 end
 
+--- Makes the character face in the direction specified by `dir`.
+---@param dir string The direction the character should face. Must be "up", "down", "left", or "right".
 function Character:setFacing(dir)
     self.facing = dir
     self.sprite:setFacing(dir)
@@ -374,6 +376,7 @@ function Character:setWalkSprite(sprite)
     self.sprite:setWalkSprite(sprite)
 end
 
+--- Resetss the character's to their default animation or sprite.
 function Character:resetSprite()
     self.sprite:resetSprite()
 end
@@ -644,6 +647,8 @@ function Character:update()
     super.update(self)
 end
 
+--- Makes the character start spinning.
+---@param speed number  The spin speed to set on the character. Negative numbers = anticlockwise, positive numbers = clockwise. Higher value = slower spin.
 function Character:spin(speed)
     self.spin_speed = speed
 end

--- a/src/engine/game/world/character.lua
+++ b/src/engine/game/world/character.lua
@@ -239,6 +239,16 @@ function Character:onFootstep(num)
     Kristal.callEvent(KRISTAL_EVENT.onFootstep, self, num)
 end
 
+--- Walks this character to a new `x` and `y` over `time` seconds.
+---@overload fun(self: Character, marker: string, time?: number, facing?: string, keep_facing?: boolean, after?: fun())
+---@param x             number                  The new `x` value to approach.
+---@param y             number                  The new `y` value to approach.
+---@param marker        string                  A map marker whose position the object should approach.
+---@param time?         number                  The amount of time, in seconds, that the slide should take. (Defaults to 1 second)
+---@param facing?       string                  The direction the character should face when they finish their walk. If `keep_facing` is `true`, they will instead face way immediately.
+---@param keep_facing?  boolean                 If `true`, the facing direction of the character will be preserved. Otherwise, they will face the direction they are walking. (Defaults to `false`)
+---@param after?        fun(chara: Character)   A callback function that is run after the character has finished walking.
+---@return boolean success Whether the walking will occur. False if the character's current position is already at the specified position, and true otherwise.
 function Character:walkTo(x, y, time, facing, keep_facing, ease, after)
     if type(x) == "string" then
         after = ease
@@ -264,6 +274,16 @@ function Character:walkTo(x, y, time, facing, keep_facing, ease, after)
     return false
 end
 
+--- Walks this character to a new `x` and `y` at `speed` pixels per frame.
+---@overload fun(self: Character, marker: string, speed?: number, facing?: string, keep_facing?: boolean, after?: fun())
+---@param x             number                  The new `x` value to approach.
+---@param y             number                  The new `y` value to approach.
+---@param marker        string                  A map marker whose position the object should approach.
+---@param speed?        number                  The amount that the object's `x` and `y` should approach the specified position, in pixels per frame at 30FPS. (Defaults to `4`)
+---@param facing?       string                  The direction the character should face when they finish their walk. If `keep_facing` is `true`, they will instead face way immediately.
+---@param keep_facing?  boolean                 If `true`, the facing direction of the character will be preserved. Otherwise, they will face the direction they are walking. (Defaults to `false`)
+---@param after?        fun(chara: Character)   A callback function that is run after the character has finished walking.
+---@return boolean success Whether the walking will occur. False if the character's current position is already at the specified position, and true otherwise.
 function Character:walkToSpeed(x, y, speed, facing, keep_facing, after)
     if type(x) == "string" then
         after = keep_facing
@@ -288,6 +308,21 @@ function Character:walkToSpeed(x, y, speed, facing, keep_facing, after)
     return false
 end
 
+--- Walks the character along a given path. 
+---@param path      string|table        The name of a path in the current map file, or a table defining several points (as additional tables) that constitute a path.
+---@param options   table               A table defining additional properties to control the walk.
+---|"facing" # The direction the character should face when they finish their walk. If `keep_facing` is `true`, they will instead face way immediately.
+---|"keep_facing" # If `true`, the facing direction of the character will be preserved. Otherwise, they will face the direction they are walking. (Defaults to `false`)
+---| "time" # The amount of time, in seconds, that the object should take to travel along the full path.
+---| "speed" # The speed at which the object should travel along the path, in pixels per frame at 30FPS.
+---| "ease" # The ease type to use when travelling along the path. Unused if `speed` is specified instead of `time`. (Defaults to "linear")
+---| "after" # A function that will be called when the end of the path is reached. Receives no arguments.
+---| "relative" # Whether the path should be relative to the object's current position, or simply set its position directly.
+---| "loop" # Whether the path should loop back to the first point when reaching the end, or if it should stop.
+---| "reverse" # If true, reverse all of the points on the path.
+---| "skip" # A number defining how many points of the path to skip.
+---| "snap" # Whether the object's position should immediately "snap" to the first point, or if its initial position should be counted as a point on the path.
+---@return nil
 function Character:walkPath(path, options)
     options = options or {}
 

--- a/src/engine/game/world/character.lua
+++ b/src/engine/game/world/character.lua
@@ -253,7 +253,9 @@ function Character:walkTo(x, y, time, facing, keep_facing, ease, after)
     if type(x) == "string" then
         after = ease
         ease = keep_facing
+        ---@diagnostic disable-next-line: cast-local-type
         keep_facing = facing
+        ---@diagnostic disable-next-line: cast-local-type
         facing = time
         time = y
         x, y = self.world.map:getMarker(x)
@@ -286,8 +288,11 @@ end
 ---@return boolean success Whether the walking will occur. False if the character's current position is already at the specified position, and true otherwise.
 function Character:walkToSpeed(x, y, speed, facing, keep_facing, after)
     if type(x) == "string" then
+        ---@diagnostic disable-next-line: cast-local-type
         after = keep_facing
+        ---@diagnostic disable-next-line: cast-local-type
         keep_facing = facing
+        ---@diagnostic disable-next-line: cast-local-type
         facing = speed
         speed = y
         x, y = self.world.map:getMarker(x)

--- a/src/engine/game/world/character.lua
+++ b/src/engine/game/world/character.lua
@@ -348,6 +348,16 @@ function Character:flash(sprite, offset_x, offset_y, layer)
     return sprite_to_use:flash(offset_x, offset_y, layer)
 end
 
+--- Creates an alert bubble (tiny !) above this character.
+---@param duration?     number  The number of frames to show the bubble for. (Defaults to `20`)
+---@param options?      table   A table defining additional properties to control the bubble.
+---|"play_sound"    # Whether the alert sound will be played. (Defaults to `true`)
+---|"sprite"        # The sprite to use for the alert bubble. (Defaults to `"effects/alert"`)
+---|"offset_x"      # The x-offset of the icon.
+---|"offset_y"      # The y-offset of the icon.
+---|"layer"         # The layer to put the icon on. (Defaults to `100`)
+---|"callback"      # A callback that is run when the alert finishes.
+---@return Sprite
 function Character:alert(duration, options)
     options = options or {}
     if options["play_sound"] == nil or options["play_sound"] then

--- a/src/engine/game/world/follower.lua
+++ b/src/engine/game/world/follower.lua
@@ -130,6 +130,7 @@ function Follower:moveToTarget(speed)
     end
 end
 
+--- Adds this follower's current position to their movement history.
 function Follower:interpolateHistory()
     local target = self:getTarget()
 

--- a/src/engine/game/world/map.lua
+++ b/src/engine/game/world/map.lua
@@ -131,6 +131,10 @@ function Map:addFlag(flag, amount)
     return Game:addFlag(uid..":"..flag, amount)
 end
 
+--- Gets a specific marker from the current map.
+---@param name string The name of the marker to search for.
+---@return number x The x-coordinate of the marker's center.
+---@return number y The y-coordinate of the marker's center.
 function Map:getMarker(name)
     local marker = self.markers[name]
     return marker and marker.center_x or (self.width * self.tile_width/2), marker and marker.center_y or (self.height * self.tile_height/2)
@@ -180,6 +184,9 @@ function Map:setTile(x, y, tileset, ...)
     tile_layer:setTile(x, y, tileset, unpack(args))
 end
 
+--- Gets a specific event present in the current map.
+---@param id string|number  The unique numerical id of an event OR the text id of an event type to get the first instance of.
+---@return Event event The event instnace, or `nil` if it was not found. 
 function Map:getEvent(id)
     if type(id) == "number" then
         return self.events_by_id[id]
@@ -190,6 +197,9 @@ function Map:getEvent(id)
     end
 end
 
+--- Gets a list of all instances of one type of event in the current map.
+---@param name string The text id of the event to search for.
+---@return table events A table containing every instance of the event in the current map.
 function Map:getEvents(name)
     if name then
         return self.events_by_name[name] or {}

--- a/src/engine/game/world/player.lua
+++ b/src/engine/game/world/player.lua
@@ -143,6 +143,11 @@ function Player:resetFollowerHistory()
     end
 end
 
+--- Aligns the player's followers' directions and positions.
+---@param facing?   string  The direction every character should face (Defaults to player's direction)
+---@param x?        number  The x-coordinate of the 'front' of the line. (Defaults to player's x-position)
+---@param y?        number  The y-coordinate of the 'front' of the line. (Defaults to player's y-position)
+---@param dist?     number  The distance between each follower.
 function Player:alignFollowers(facing, x, y, dist)
     facing = facing or self.facing
     x, y = x or self.x, y or self.y
@@ -168,6 +173,7 @@ function Player:alignFollowers(facing, x, y, dist)
     self:resetFollowerHistory()
 end
 
+--- Adds all followers' current positions to their movement history.
 function Player:interpolateFollowers()
     for i, follower in ipairs(Game.world.followers) do
         if follower:getTarget() == self then

--- a/src/engine/game/world/worldcutscene.lua
+++ b/src/engine/game/world/worldcutscene.lua
@@ -198,6 +198,7 @@ end
 ---@param dir?      string              The direction the character should face. Must be either "up", "dowm", "left", or "right". (Defaults to "down")
 function WorldCutscene:look(chara, dir)
     if not dir then
+        ---@diagnostic disable-next-line: cast-local-type
         dir = chara or "down"
         chara = self.world.player
     elseif type(chara) == "string" then
@@ -348,6 +349,7 @@ function WorldCutscene:slideTo(obj, x, y, time, ease)
         obj = self:getCharacter(obj)
     end
     if type(x) == "string" then
+        ---@diagnostic disable-next-line: cast-local-type
         ease = time
         time = y
         x, y = self.world.map:getMarker(x)

--- a/src/engine/game/world/worldcutscene.lua
+++ b/src/engine/game/world/worldcutscene.lua
@@ -1,3 +1,6 @@
+--- The cutscene class for cutscenes playing in the world, their scripts should be located in `scripts/world/cutscenes`. \
+--- These cutscene scripts will receive a WorldCutscene as their first argument.
+---
 ---@class WorldCutscene : Cutscene
 ---
 ---@field textbox           Textbox     The current Textbox object, if it is active.
@@ -203,6 +206,17 @@ function WorldCutscene:look(chara, dir)
     chara:setFacing(dir)
 end
 
+--- Walks a character to a new `x` and `y` over `time` seconds.
+---@overload fun(self: WorldCutscene, chara: Character|string, marker: string, time?: number, facing?: string, keep_facing?: boolean, after?: fun())
+---@param chara         Character|string        The Character instance or id to make walk.
+---@param x             number                  The new `x` value to approach.
+---@param y             number                  The new `y` value to approach.
+---@param marker        string                  A map marker whose position the object should approach.
+---@param time?         number                  The amount of time, in seconds, that the slide should take. (Defaults to 1 second)
+---@param facing?       string                  The direction the character should face when they finish their walk. If `keep_facing` is `true`, they will instead face way immediately.
+---@param keep_facing?  boolean                 If `true`, the facing direction of the character will be preserved. Otherwise, they will face the direction they are walking. (Defaults to `false`)
+---@param after?        fun(chara: Character)   A callback function that is run after the character has finished walking.
+---@return fun(): boolean finished A function that returns `true` once the character has finished walking.
 function WorldCutscene:walkTo(chara, x, y, time, facing, keep_facing, ease, after)
     if type(chara) == "string" then
         chara = self:getCharacter(chara)
@@ -217,6 +231,17 @@ function WorldCutscene:walkTo(chara, x, y, time, facing, keep_facing, ease, afte
     end
 end
 
+--- Walks a character to a new `x` and `y` at `speed` pixels per frame.
+---@overload fun(self: WorldCutscene, chara: Character|string, marker: string, speed?: number, facing?: string, keep_facing?: boolean, after?: fun())
+---@param chara         Character|string        The Character instance or id to make walk.
+---@param x             number                  The new `x` value to approach.
+---@param y             number                  The new `y` value to approach.
+---@param marker        string                  A map marker whose position the object should approach.
+---@param speed?        number                  The amount that the object's `x` and `y` should approach the specified position, in pixels per frame at 30FPS. (Defaults to `4`)
+---@param facing?       string                  The direction the character should face when they finish their walk. If `keep_facing` is `true`, they will instead face way immediately.
+---@param keep_facing?  boolean                 If `true`, the facing direction of the character will be preserved. Otherwise, they will face the direction they are walking. (Defaults to `false`)
+---@param after?        fun(chara: Character)   A callback function that is run after the character has finished walking.
+---@return fun(): boolean finished A function that returns `true` once the character has finished walking.
 function WorldCutscene:walkToSpeed(chara, x, y, speed, facing, keep_facing, after)
     if type(chara) == "string" then
         chara = self:getCharacter(chara)
@@ -231,6 +256,22 @@ function WorldCutscene:walkToSpeed(chara, x, y, speed, facing, keep_facing, afte
     end
 end
 
+--- Walks a character along a path.
+---@param chara     Character|string    The Character instance or id to make walk.
+---@param path      string|table        The name of a path in the current map file, or a table defining several points (as additional tables) that constitute a path.
+---@param options   table               A table defining additional properties to control the walk.
+---|"facing" # The direction the character should face when they finish their walk. If `keep_facing` is `true`, they will instead face way immediately.
+---|"keep_facing" # If `true`, the facing direction of the character will be preserved. Otherwise, they will face the direction they are walking. (Defaults to `false`)
+---| "time" # The amount of time, in seconds, that the object should take to travel along the full path.
+---| "speed" # The speed at which the object should travel along the path, in pixels per frame at 30FPS.
+---| "ease" # The ease type to use when travelling along the path. Unused if `speed` is specified instead of `time`. (Defaults to "linear")
+---| "after" # A function that will be called when the end of the path is reached. Receives no arguments.
+---| "relative" # Whether the path should be relative to the object's current position, or simply set its position directly.
+---| "loop" # Whether the path should loop back to the first point when reaching the end, or if it should stop.
+---| "reverse" # If true, reverse all of the points on the path.
+---| "skip" # A number defining how many points of the path to skip.
+---| "snap" # Whether the object's position should immediately "snap" to the first point, or if its initial position should be counted as a point on the path.
+---@return fun() : boolean finished Returns `true` when the character has reached the end of the path.
 function WorldCutscene:walkPath(chara, path, options)
     if type(chara) == "string" then
         chara = self:getCharacter(chara)
@@ -293,6 +334,15 @@ function WorldCutscene:spin(chara, speed)
     chara:spin(speed)
 end
 
+--- Moves the object's `x` and `y` values to the new specified position over `time` seconds.
+---@overload fun(self:WorldCutscene, obj:Object|string, time?:number, ease?:string, after?:function) : finished: fun(): boolean
+---@param obj    Object|string  The object instance or id of a character to slide.
+---@param x      number         The new `x` value to approach.
+---@param y      number         The new `y` value to approach.
+---@param marker string         A map marker whose position the object should approach.
+---@param time?  number         The amount of time, in seconds, that the slide should take. (Defaults to 1 second)
+---@param ease?  string         The ease type to use when moving to the new position. (Defaults to "linear")
+---@return fun() : boolean finished A function that returns `true` once the object has reached its destination.
 function WorldCutscene:slideTo(obj, x, y, time, ease)
     if type(obj) == "string" then
         obj = self:getCharacter(obj)
@@ -311,6 +361,14 @@ function WorldCutscene:slideTo(obj, x, y, time, ease)
     end
 end
 
+--- Moves the object's `x` and `y` values to the new specified position at a speed of `speed` pixels per frame.
+---@overload fun(self:WorldCutscene, obj:Object|string, marker:string, speed?:number, ease?:string) : finished: fun(): boolean
+---@param obj    Object|string      The object instance or id of a character to slide.
+---@param x      number             The new `x` value to approach.
+---@param y      number             The new `y` value to approach.
+---@param marker string             A map marker whose position the object should approach.
+---@param speed? number             The amount that the object's `x` and `y` should approach the specified position, in pixels per frame at 30FPS. (Defaults to `4`)
+---@return fun() : boolean finished A function that returns `true` once the object has reached its destination.
 function WorldCutscene:slideToSpeed(obj, x, y, speed)
     if type(obj) == "string" then
         obj = self:getCharacter(obj)
@@ -328,6 +386,21 @@ function WorldCutscene:slideToSpeed(obj, x, y, speed)
     end
 end
 
+--- Slides an object along a path.
+---@param obj       Object|string   The object instance or id of a character to slide.
+---@param path      string|table    The name of a path in the current map file, or a table defining several points (as additional tables) that constitute a path.
+---@param options?  table           A table defining additional properties that the slide should use.
+---| "time" # The amount of time, in seconds, that the object should take to travel along the full path.
+---| "speed" # The speed at which the object should travel along the path, in pixels per frame at 30FPS.
+---| "ease" # The ease type to use when travelling along the path. Unused if `speed` is specified instead of `time`. (Defaults to "linear")
+---| "after" # A function that will be called when the end of the path is reached. Receives no arguments.
+---| "move_func" # A function called every frame while the object is travelling along the path. Receives `self` and the `x` and `y` offset from the previous frame as arguments.
+---| "relative" # Whether the path should be relative to the object's current position, or simply set its position directly.
+---| "loop" # Whether the path should loop back to the first point when reaching the end, or if it should stop.
+---| "reverse" # If true, reverse all of the points on the path.
+---| "skip" # A number defining how many points of the path to skip.
+---| "snap" # Whether the object's position should immediately "snap" to the first point, or if its initial position should be counted as a point on the path.
+---@return function finished Returns `true` when the object has reached the end of the path.
 function WorldCutscene:slidePath(obj, path, options)
     if type(obj) == "string" then
         obj = self:getCharacter(obj)
@@ -350,6 +423,10 @@ function WorldCutscene:slidePath(obj, path, options)
     return function() return slided end
 end
 
+---comment
+---@param chara any
+---@param ... unknown
+---@return function
 function WorldCutscene:jumpTo(chara, ...)
     if type(chara) == "string" then
         chara = self:getCharacter(chara)
@@ -388,7 +465,7 @@ end
 ---@param ...       unknown             Arguments to be passed to Character:alert().
 ---@return Sprite   alert_icon          The result alert icon created above the character's head.
 ---@return fun()    finished            A function that returns `true` once the alert icon has disappeared. \
----@see Character - Character:alert() for details on the arguments to pass to this function.
+---@see Character.alert for details on the arguments to pass to this function.
 function WorldCutscene:alert(chara, ...)
     if type(chara) == "string" then
         chara = self:getCharacter(chara)
@@ -520,9 +597,9 @@ function WorldCutscene:panToSpeed(...)
 end
 
 --- Loads a new map and starts the transition effects for world music, borders, and the screen as a whole.
----@overload fun(self: WorldCutscene, map: string, ...: any)
+---@overload fun(self: WorldCutscene, map: string, ...: any) : finished: fun(): boolean
 ---@param ... any   Additional arguments that will be passed into World:loadMap()
----@see World - World:loadMap() for the arguments to pass into World:loadMap().
+---@see World.loadMap for the arguments to pass into World:loadMap().
 ---@return fun() : boolean finished A function that returns true once the map transition has finished. \
 function WorldCutscene:mapTransition(...)
     self.world:mapTransition(...)
@@ -593,7 +670,38 @@ function WorldCutscene:fadeIn(speed, options)
     return function() return fade_done end
 end
 
+-- DOC Note: WorldCutscene:text() is a chunky function (for good reason) but
+-- there's two optional properties - "functions" and "reactions", that are
+-- woefully large (and honestly i just copied and tweaked the GitHub wiki 
+-- descriptions) and they don't just appear here (see BattleCutscene:text())
+-- we could do with somewhere dedicated to these two because it REALLY feels like
+-- they aren't done justice here. Seeing their relation with text - it'd be nice
+-- to move their explanations to a wiki page about text rather than being stuffed
+-- up in these functions.
+
 local function waitForTextbox(self) return not self.textbox or self.textbox:isDone() end
+--- Creates a new textbox and starts typing the given `text` into it. \
+--- Will pause the cutscene until the textbox is closed, unless otherwise specified via `options`.
+---@overload fun(self: WorldCutscene, text: string, options?: table) : (finished:(fun():boolean), textbox: Textbox?)
+---@overload fun(self: WorldCutscene, text: string, portrait: string, options?: table) : (finished:(fun():boolean), textbox: Textbox?)
+---@param text      string                      The text to be typed.
+---@param portrait  string|nil                  The name of the character portrait to use for this textbox.
+---@param actor     Character|Actor|string|nil  The Character/Actor to be used for voice bytes and portraits, overriding the active cutscene speaker.
+---@param options?  table                       A table definining additional properties to control the textbox.
+---|"talk"      # If a `Character` instance is attached to the textbox, whether they should use their talk sprite in world. 
+---|"top"       # Override for the default textbox position, defining whether the textbox should appear at the top of the screen.
+---|"x"         # The x-offset of the dialgoue portrait.
+---|"y"         # The y-offset of the dialogue portrait.
+---|"reactions" # A table of tables that define "reaction" dialogues. Each table defines the dialogue, x and y position of the face, actor and face sprite, in that order. x and y can be strings as well, referring to existing positions; x can be left, leftmid, mid, middle, rightmid, or right, and y can be top, mid, middle, bottommid, and bottom. Must be used in combination with a react text command.
+---|"functions" # A table defining additional functions that can be used in the text with the `func` text command. Each key, value pair will form the id to use with `func` and the function to be called, respectively.
+---|"font"      # The font to be used for this text. Can optionally be defined as a table {font, size} to also set the text size.
+---|"align"     # Sets the alignment of the text.
+---|"skip"      # If false, the player will be unable to skip the textbox with the cancel key.
+---|"advance"   # When `false`, the player cannot advance the textbox, and the cutscene will no longer suspend itself on the dialogue by default.
+---|"auto"      # When `true`, the text will auto-advance after the last character has been typed.
+---|"wait"      # Whether the cutscene should automatically suspend itself until the textbox advances. (Defaults to `true`, unless `advance` is false.)
+---@return fun() : boolean  finished    A function that returns `true` once the textbox has closed. (Only use if `options["wait"]` is set to `false`.)
+---@return Textbox?         textbox     The Textbox object that has been created. (Only use if `options["wait"]` is set to `false`.)
 function WorldCutscene:text(text, portrait, actor, options)
     if type(actor) == "table" and not isClass(actor) then
         options = actor
@@ -713,6 +821,15 @@ function WorldCutscene:closeText()
 end
 
 local function waitForChoicer(self) return self.choicebox.done, self.choicebox.selected_choice end
+--- Creates a choicer with the choices specified in `choices` for the player to select from.
+---@param choices  table A table of strings specifying the choices the player can select. Maximum of four.
+---@param options? table A table defining additional properties to control the choicer.
+---|"top"       # Override for the default textbox position, defining whether the choicer should appear at the top of the screen.
+---|"color"     # The main color to set all the choices to, or a table of main colors to set for different choices. (Defaults to `COLORS.white`)
+---|"highlight" # The color to highlight the selected choice in, or a table of colors to highlight different choices in when selected. (Defaults to `COLORS.yellow`)
+---|"wait"      # Whether the cutscene should automatically suspend itself until the player makes their choice. (Defaults to `true`)
+---@return number|function selected The index of the selected item if the cutscene has been set to wait for the choicer, otherwise a boolean that states whether the player has made their choice.
+---@return Choicebox? choicer The choicebox object for this choicer. Only returned if wait is `false`. 
 function WorldCutscene:choicer(choices, options)
     self:closeText()
 
@@ -751,6 +868,24 @@ function WorldCutscene:choicer(choices, options)
 end
 
 local function waitForTextChoicer(self) return not self.textchoicebox or self.textchoicebox:isDone(), self.textchoicebox.selected_choice end
+--- Creates a Text Choicer - A textbox that includes both dialogue and a choicer.
+---@param text      string                      The text to be typed.
+---@param choices   table                       A table of strings specifying the choices the player can select.
+---@param portrait  string|nil                  The name of the character portrait to use for this textbox.
+---@param actor     Character|Actor|string|nil  The Character/Actor to be used for voice bytes and portraits, overriding the active cutscene speaker.
+---@param options?  table                       A table definining additional properties to control the textbox.
+---|"talk"      # If a `Character` instance is attached to the textbox, whether they should use their talk sprite in world. 
+---|"top"       # Override for the default textbox position, defining whether the textbox should appear at the top of the screen.
+---|"x"         # The x-offset of the dialgoue portrait.
+---|"y"         # The y-offset of the dialogue portrait.
+---|"reactions" # A table of tables that define "reaction" dialogues. Each table defines the dialogue, x and y position of the face, actor and face sprite, in that order. x and y can be strings as well, referring to existing positions; x can be left, leftmid, mid, middle, rightmid, or right, and y can be top, mid, middle, bottommid, and bottom. Must be used in combination with a react text command.
+---|"functions" # A table defining additional functions that can be used in the text with the `func` text command. Each key, value pair will form the id to use with `func` and the function to be called, respectively.
+---|"font"      # The font to be used for this text. Can optionally be defined as a table {font, size} to also set the text size.
+---|"align"     # Sets the alignment of the text.
+---|"skip"      # If false, the player will be unable to skip the textbox with the cancel key.
+---|"wait"      # Whether the cutscene should automatically suspend itself until the player selects a choice. (Defaults to `true`)
+---@return fun() : boolean  finished    A function that returns `true` once the textbox has closed. (Only use if `options["wait"]` is set to `false`.)
+---@return TextChoicebox    textbox     The TextboxChoicer object that has been created. (Only use if `options["wait"]` is set to `false`.)
 function WorldCutscene:textChoicer(text, choices, portrait, actor, options)
     if type(actor) == "table" and not isClass(actor) then
         options = actor
@@ -850,12 +985,14 @@ end
 
 --- Starts an encounter within the current cutscene. \
 --- The cutscene will resume at the end of the encounter, once the transition out from battle is complete.
----@param encounter     string
----@param transition    boolean|string
----@param enemy         Character|string
----@param options       table
----@return fun()        finished
----@return Encounter?   encounter
+---@param encounter     Encounter|string    The encounter id or instance to use for this battle.
+---@param transition?   boolean|string      Whether to start in the transition state (Defaults to `true`). As a string, represents the state to start the battle in.
+---@param enemy?        Character|table     An enemy instance or list of enemies as `Character`s in the world that will transition into the battle.
+---@param options       table               A table defining additional properties to control the encounter.
+---|"on_start"  # A callback that is run when the battle starts (Exits the `"TRANSITION"` state). Runs immediately if the transition is skipped.
+---|"wait"      # Whether the cutscene should be suspended until the encounter is complete. (Deftualts to `true`)
+---@return fun()        finished    A function that returns `true` when the encounter has finished. (Only use if options.wait is set to `false`)
+---@return Encounter?   encounter   The Encounter instance for the battle started by this function call. (Only use if options.wait is set to `false`)
 function WorldCutscene:startEncounter(encounter, transition, enemy, options)
     options = options or {}
     transition = transition ~= false

--- a/src/engine/object.lua
+++ b/src/engine/object.lua
@@ -534,7 +534,7 @@ function Object:slideTo(x, y, time, ease, after)
 end
 
 --- Moves the object's `x` and `y` values to the new specified position at a speed of `speed` pixels per frame.
----@overload fun(self:Object, marker:string, time?:number, ease?:string, after?:function): success:boolean
+---@overload fun(self:Object, marker:string, speed?:number, after?:function): success:boolean
 ---@param x      number   The new `x` value to approach.
 ---@param y      number   The new `y` value to approach.
 ---@param marker string   A map marker whose position the object should approach.

--- a/src/engine/objects/fader.lua
+++ b/src/engine/objects/fader.lua
@@ -81,6 +81,7 @@ end
 
 --- Starts a fade out with the given options. \
 --- A default fadeout will fade to black over `0.25` seconds, fading out the music as well.
+---@overload fun(self: Fader, options: table)
 ---@param callback  function    A function that will be called when the fade has finished.
 ---@param options   table       A table defining additional properties to control the fade.
 ---| "speed"    # The speed to fade out at, in seconds. (Defaults to `0.25`)
@@ -91,6 +92,7 @@ end
 function Fader:fadeOut(callback, options)
     if type(callback) == "table" then
         options = callback
+        ---@diagnostic disable-next-line: cast-local-type
         callback = nil
     end
     self:parseOptions(options, true)
@@ -101,6 +103,7 @@ end
 
 --- Fades the screen back in with the given options and based on the previous fade out. \
 --- A default fadein will fade the screen and music in over `0.25` seconds.
+---@overload fun(self: Fader, options: table)
 ---@param callback  function    A function that will be called when the fade has finished.
 ---@param options   table       A table defining additional properties to control the fade.
 ---| "speed"    # The speed to fade in at, in seconds (Defaults to last fadeOut's speed.)
@@ -111,6 +114,7 @@ end
 function Fader:fadeIn(callback, options)
     if type(callback) == "table" then
         options = callback
+        ---@diagnostic disable-next-line: cast-local-type
         callback = nil
     end
     self:parseOptions(options, false)

--- a/src/engine/objects/fader.lua
+++ b/src/engine/objects/fader.lua
@@ -26,6 +26,9 @@ function Fader:init()
     self.blocky = false
 end
 
+--- *(Called internally)* Processes the `options` table for fades, setting values for the appropriate fields.
+---@param options table         The table of options for the current fade.
+---@param reset_values boolean  Whether to reset values from previous fades. (Usually `true` when fading out, and `false` when fading in)
 function Fader:parseOptions(options, reset_values)
     options = options or {}
 
@@ -37,6 +40,9 @@ function Fader:parseOptions(options, reset_values)
     return options
 end
 
+--- *(Called internally)* Processes music fading with the `options` table for fades.
+---@param to        number  The volume to fade the music to.
+---@param options   table   The table of options for the current fade.
 function Fader:parseMusicFade(to, options)
     options = options or {}
     if options["music"] then
@@ -73,6 +79,15 @@ function Fader:transition(middle_callback, end_callback, options)
     end, options)
 end
 
+--- Starts a fade out with the given options. \
+--- A default fadeout will fade to black over `0.25` seconds, fading out the music as well.
+---@param callback  function    A function that will be called when the fade has finished.
+---@param options   table       A table defining additional properties to control the fade.
+---| "speed"    # The speed to fade out at, in seconds. (Defaults to `0.25`)
+---| "color"    # The color that should be faded to (Defaults to `COLORS.black`)
+---| "alpha"    # The alpha to start at (Defaults to `0`)
+---| "blocky"   # Whether to do a rough, 'blocky' fade. (Defaults to `false`)
+---| "music"    # The speed to fade the music at, or whether to fade it at all (Defaults to fade speed)
 function Fader:fadeOut(callback, options)
     if type(callback) == "table" then
         options = callback
@@ -84,6 +99,15 @@ function Fader:fadeOut(callback, options)
     self.state = "FADEOUT"
 end
 
+--- Fades the screen back in with the given options and based on the previous fade out. \
+--- A default fadein will fade the screen and music in over `0.25` seconds.
+---@param callback  function    A function that will be called when the fade has finished.
+---@param options   table       A table defining additional properties to control the fade.
+---| "speed"    # The speed to fade in at, in seconds (Defaults to last fadeOut's speed.)
+---| "color"    # The color that should be faded to (Defaults to last fadeOut's color)
+---| "alpha"    # The alpha to start at (Defaults to `1`)
+---| "blocky"   # Whether to do a rough, 'blocky' fade. (Defaults to `false`)
+---| "music"    # The speed to fade the music at, or whether to fade it at all (Defaults to fade speed)
 function Fader:fadeIn(callback, options)
     if type(callback) == "table" then
         options = callback


### PR DESCRIPTION
Adds code documentation for the functions available for use in cutscenes. There's also a sprinkling of other things because some things didn't make sense to not document when they were very closely linked to cutscene functions