### PR TITLE
Call setFrame to update the texture in Sprite:setFrames

### DIFF
--- a/src/engine/objects/sprite.lua
+++ b/src/engine/objects/sprite.lua
@@ -213,8 +213,9 @@ function Sprite:setFrames(frames, keep_anim)
     end
     if not keep_anim then
         self:stop()
+    else
+        self:setFrame(self.frame) -- this also clamps self.frame
     end
-    self:updateTexture()
 end
 
 ---@alias Sprite.wait_func     fun(seconds:number)


### PR DESCRIPTION
This makes sure the frame number is clamped,
in case a sprite changes its animation to one
with lesser frames than the previous one.