### PR TITLE
In WorldCutscene:text try converting string-type actor to Character

### DIFF
--- a/src/engine/game/world/worldcutscene.lua
+++ b/src/engine/game/world/worldcutscene.lua
@@ -488,6 +488,10 @@ function WorldCutscene:text(text, portrait, actor, options)
     self.world:addChild(self.textbox)
     self.textbox:setParallax(0, 0)
 
+    if type(actor) == "string" then
+        actor = self:getCharacter(actor) or actor
+    end
+
     local speaker = self.textbox_speaker
     if not speaker and isClass(actor) and actor:includes(Character) then
         speaker = actor.sprite
@@ -646,6 +650,10 @@ function WorldCutscene:textChoicer(text, choices, portrait, actor, options)
 
     for _,choice in ipairs(choices) do
         self.textchoicebox:addChoice(choice)
+    end
+
+    if type(actor) == "string" then
+        actor = self:getCharacter(actor) or actor
     end
 
     local speaker = self.textbox_speaker


### PR DESCRIPTION
This makes animating talksprite work even if no speaker is set beforehand and a string is passed as actor