### PR TITLE
Add Tracker formats

### DIFF
--- a/src/engine/loadthread.lua
+++ b/src/engine/loadthread.lua
@@ -327,7 +327,11 @@ local loaders = {
         local id = checkExtension(path, "mp3", "wav", "ogg",
             -- TRACKER FORMATS
             "mod", "s3m", "xm", "it", "669", "amf", "ams", "dbm", "dmf", "dsm", "far",
-            "mdl", "med", "mtm", "okt", "ptm", "stm", "ult", "umx", "mt2", "psm"
+            "mdl", "med", "mtm", "okt", "ptm", "stm", "ult", "umx", "mt2", "psm",
+            -- COMPRESSED TRACKER FORMATS
+            "mdz", "s3z", "xmz", "itz", "zip",
+            "mdr", "s3r", "xmr", "itr", "rar",
+            "mdgz", "s3gz", "xmgz", "itgz", "gz"
         )
         if id then
             data.assets.music[id] = full_path

--- a/src/engine/loadthread.lua
+++ b/src/engine/loadthread.lua
@@ -324,7 +324,11 @@ local loaders = {
         end
     end },
     ["music"] = { "assets/music", function (base_dir, path, full_path)
-        local id = checkExtension(path, "mp3", "wav", "ogg")
+        local id = checkExtension(path, "mp3", "wav", "ogg",
+            -- TRACKER FORMATS
+            "mod", "s3m", "xm", "it", "669", "amf", "ams", "dbm", "dmf", "dsm", "far",
+            "mdl", "med", "mtm", "okt", "ptm", "stm", "ult", "umx", "mt2", "psm"
+        )
         if id then
             data.assets.music[id] = full_path
         end


### PR DESCRIPTION
Adds searching support for XM, ImpulseTracker, and twenty other formats supported by ModPlug (and therefore LÖVE).

* [LÖVE Wiki](https://love2d.org/wiki/Tutorial:Audio#Formats)
* [ModPlug README](http://sourceforge.net/p/modplug-xmms/git/ci/master/tree/libmodplug/README#l39)
