### PR TITLE
Fix crash on attempt to remove an enemy that was already removed

### DIFF
--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -2229,7 +2229,10 @@ end
 function Battle:update()
     for _,enemy in ipairs(self.enemies_to_remove) do
         Utils.removeFromTable(self.enemies, enemy)
-        self.enemies_index[Utils.getKey(self.enemies_index, enemy)] = false
+        local enemy_y = Utils.getKey(self.enemies_index, enemy)
+        if enemy_y then
+            self.enemies_index[enemy_y] = false
+        end
     end
     self.enemies_to_remove = {}
 


### PR DESCRIPTION
The engine simply ignored such attempts,
until #134 made the engine also remove the
enemy from Battle.enemies_index, which
introduced a crash as it did not check if
the enemy is actually in enemies_index.
This introduces a nil check for getKey's result to
ensure that and restore the old behavior.