### PR TITLE
Chapter 1 equip inventory size and scroller

### DIFF
--- a/configs/chapter1.json
+++ b/configs/chapter1.json
@@ -2,6 +2,7 @@
     "enableStorage": false,          // Extra 48-slot item storage
     "enableRecruits": false,         // Enable recruit messages and menu
     "smallSaveMenu": true,           // Single-file save menu with no storage/recruits options
+    "lessEquipments": true,          // Reduces the amount of available weapons and armor slots in the inventory
 
     "partyActions": false,           // Whether X-Actions appear in spell menu by default
 

--- a/configs/chapter2.json
+++ b/configs/chapter2.json
@@ -2,6 +2,7 @@
     "enableStorage": true,           // Extra 48-slot item storage
     "enableRecruits": true,          // Enable recruit messages and menu
     "smallSaveMenu": false,          // Single-file save menu with no storage/recruits options
+    "lessEquipments": false,         // Reduces the amount of available weapons and armor slots in the inventory
 
     "partyActions": true,            // Whether X-Actions appear in spell menu by default
 

--- a/src/engine/game/common/darkinventory.lua
+++ b/src/engine/game/common/darkinventory.lua
@@ -26,7 +26,7 @@ function DarkInventory:clear()
         ["key_items"] = {id = "key_items", max = 12,                       sorted = true,  name = "KEY ITEMs",   fallback = nil      },
         ["weapons"]   = {id = "weapons",   max = Game.default_equip_slots, sorted = false, name = "WEAPONs",     fallback = nil      },
         ["armors"]    = {id = "armors",    max = Game.default_equip_slots, sorted = false, name = "ARMORs",      fallback = nil      },
-        ["storage"]   = {id = "storage",   max = 24,      
+        ["storage"]   = {id = "storage",   max = 24,                       sorted = false, name = "STORAGE",     fallback = nil      },
 
         ["light"]     = {id = "light",     max = 28,                       sorted = true,  name = "LIGHT ITEMs", fallback = nil      },
     }

--- a/src/engine/game/common/darkinventory.lua
+++ b/src/engine/game/common/darkinventory.lua
@@ -22,13 +22,13 @@ function DarkInventory:clear()
     super.clear(self)
 
     self.storages = {
-        ["items"]     = {id = "items",     max = 12, sorted = true,  name = "ITEMs",       fallback = "storage"},
-        ["key_items"] = {id = "key_items", max = 12, sorted = true,  name = "KEY ITEMs",   fallback = nil      },
-        ["weapons"]   = {id = "weapons",   max = 48, sorted = false, name = "WEAPONs",     fallback = nil      },
-        ["armors"]    = {id = "armors",    max = 48, sorted = false, name = "ARMORs",      fallback = nil      },
-        ["storage"]   = {id = "storage",   max = 24, sorted = false, name = "STORAGE",     fallback = nil      },
+        ["items"]     = {id = "items",     max = 12,                       sorted = true,  name = "ITEMs",       fallback = "storage"},
+        ["key_items"] = {id = "key_items", max = 12,                       sorted = true,  name = "KEY ITEMs",   fallback = nil      },
+        ["weapons"]   = {id = "weapons",   max = Game.default_equip_slots, sorted = false, name = "WEAPONs",     fallback = nil      },
+        ["armors"]    = {id = "armors",    max = Game.default_equip_slots, sorted = false, name = "ARMORs",      fallback = nil      },
+        ["storage"]   = {id = "storage",   max = 24,      
 
-        ["light"]     = {id = "light",     max = 28, sorted = true,  name = "LIGHT ITEMs", fallback = nil      },
+        ["light"]     = {id = "light",     max = 28,                       sorted = true,  name = "LIGHT ITEMs", fallback = nil      },
     }
 
     Kristal.callEvent(KRISTAL_EVENT.createDarkInventory, self)

--- a/src/engine/game/game.lua
+++ b/src/engine/game/game.lua
@@ -200,6 +200,8 @@ function Game:save(x, y)
     for _,party in ipairs(self.party) do
         table.insert(data.party, party.id)
     end
+    
+    data.default_equip_slots = self.default_equip_slots
 
     data.inventory = self.inventory:save()
 
@@ -325,6 +327,11 @@ function Game:load(data, index, fade)
         map = Registry.createMap(room_id, self.world)
 
         self.light = map.light or false
+    end
+    
+    self.default_equip_slots = data.default_equip_slots or 48
+    if self.is_new_file and Game:getConfig("lessEquipments") then
+        self.default_equip_slots = 12
     end
 
     if self.light then

--- a/src/engine/game/world/ui/dark/darkequipmenu.lua
+++ b/src/engine/game/world/ui/dark/darkequipmenu.lua
@@ -443,6 +443,23 @@ function DarkEquipMenu:drawItems()
             if scroll > 1 then
                 Draw.draw(self.arrow_sprite, x + 187, y + 14 - sine_off, 0, 1, -1)
             end
+        end
+        if items.max <= 12 then
+            Draw.setColor(1, 1, 1)
+            for i = 1, items.max do
+                local item = items[i]
+                local percentage = (i - 1) / (items.max - 1)
+                if self.selected_item[type] == i and item then
+                    love.graphics.rectangle("fill", x + 188, y + 21 + percentage * 110, 10, 10)
+                elseif self.selected_item[type] == i then
+                    love.graphics.rectangle("fill", x + 189, y + 22 + percentage * 110, 8, 8)
+                elseif item then
+                    love.graphics.rectangle("fill", x + 191, y + 24 + percentage * 110, 4, 4)
+                else
+                    love.graphics.rectangle("fill", x + 192, y + 25 + percentage * 110, 2, 2)
+                end
+            end
+        else
             Draw.setColor(0.25, 0.25, 0.25)
             love.graphics.rectangle("fill", x + 191, y + 24, 6, 119)
             local percent = (scroll - 1) / (items.max - 6)

--- a/src/engine/menu/mainmenumodconfig.lua
+++ b/src/engine/menu/mainmenumodconfig.lua
@@ -205,6 +205,7 @@ function MainMenuModConfig:registerOptions()
     self:registerOption("enableStorage",          "Enable Storage",            "Extra 48-slot item storage",                                                         "selection", {nil, true, false})
     self:registerOption("enableRecruits",         "Enable Recruits",           "Enable recruit messages and menu",                                                   "selection", {nil, true, false})
     self:registerOption("smallSaveMenu",          "Small Save Menu",           "Single-file save menu with no storage/recruits options",                             "selection", {nil, true, false})
+    self:registerOption("lessEquipments",         "Less Equipments",           "Reduces the amount of available weapons and armor slots in the inventory",           "selection", {nil, true, false})
     self:registerOption("partyActions",           "X-Actions",                 "Whether X-Actions appear in spell menu by default",                                  "selection", {nil, true, false})
     self:registerOption("growStronger",           "Grow Stronger",             "Stat increases after defeating an enemy with violence",                              "selection", {nil, true, false})
     self:registerOption("growStrongerChara",      "Grow Stronger Character",   "The character who grows stronger if they're in the party",                           "selection", {nil, false, "kris", "ralsei", "susie", "noelle"}) -- unhardcode


### PR DESCRIPTION
In chapter 1, you only have 12 equippable items max per category.

For existing saves, it will always be 48 slots to not break them.