### PR TITLE
Make chasing and pacing not clash

### DIFF
--- a/src/engine/game/world/chaserenemy.lua
+++ b/src/engine/game/world/chaserenemy.lua
@@ -276,7 +276,7 @@ function ChaserEnemy:update()
             end
 
             self:snapToPath()
-        elseif self.pace_type then
+        elseif self.pace_type and not self.alert_icon and not self.chasing then
             self:paceMovement()
         end
 


### PR DESCRIPTION
Accidentally forgot to add this check for pacing not to happen if the enemy is chasing the player or alerted of them