### PR TITLE
Mobile external files

### DIFF
--- a/conf.lua
+++ b/conf.lua
@@ -28,4 +28,6 @@ function love.conf(t)
         t.window.highdpi = true
         t.window.usedpiscale = false
     end
+	
+	t.externalstorage = true
 end


### PR DESCRIPTION
A one-line change to allow mobile users to add mods and save files to their Kristal files.