### PR TITLE
Change the input type of `isClass()` to `any`

### DIFF
--- a/src/utils/class.lua
+++ b/src/utils/class.lua
@@ -3,7 +3,7 @@ MOD_SUBCLASSES = {}
 DEFAULT_CLASS_NAME_GETTER = function(k) return _G[k] end
 CLASS_NAME_GETTER = DEFAULT_CLASS_NAME_GETTER
 
----@param o table
+---@param o any
 ---@diagnostic disable-next-line: lowercase-global
 function isClass(o)
     return type(o) == "table" and getmetatable(o) and true or false


### PR DESCRIPTION
`isClass()` can be used on any variable type (and is throughout the code) despite previously being marked as `table` only