### PR TITLE
Created a Kristal Event for when the engine has encountered an error

### DIFF
--- a/src/engine/vars.lua
+++ b/src/engine/vars.lua
@@ -257,6 +257,9 @@ KRISTAL_EVENT = {
     --debug events--
     registerDebugContext = "registerDebugContext", -- new debug ContextMenu created / at: DebugSystem:onMousePressed(x, y, button, istouch, presses), DebugSystem:openObjectContext(object) / passes: ContextMenu:context, Object:selected_object / return: NONE
 	registerDebugOptions = "registerDebugOptions", -- DebugSystem is ready to recieve custom debug options / passes: DebugSystem:self / returns: NONE
+    
+    --engine events--
+    onError = "onError", -- the engine has encountered an error and force-stopped everything / at: Kristal.errorHandler(msg) / passes: NONE / returns: NONE
 
     --asset registration events-- (sorted by execution order)
     onRegisterActors = "onRegisterActors", -- actor scripts finished registering / in: Registry.initActors() / passes: NONE / returns: NONE

--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -528,6 +528,8 @@ end
 ---@param  msg string|table     The error message.
 ---@return function|nil handler The error handler, called every frame instead of the main loop.
 function Kristal.errorHandler(msg)
+    Kristal.callEvent(KRISTAL_EVENT.onError)
+    
     local copy_color = { 1, 1, 1, 1 }
     local anim_index = 1
     local starwalker_error = (love.math.random(100) <= 5) -- 5% chance for starwalker


### PR DESCRIPTION
Allows you to execute stuff when getting an error. Good example is just executing your unload code.