### PR TITLE
Documentation for all Events

### DIFF
--- a/mods/_testmod/scripts/world/maps/alley4.lua
+++ b/mods/_testmod/scripts/world/maps/alley4.lua
@@ -10,7 +10,7 @@ return {
   tilewidth = 40,
   tileheight = 40,
   nextlayerid = 15,
-  nextobjectid = 121,
+  nextobjectid = 123,
   properties = {},
   tilesets = {
     {
@@ -400,6 +400,20 @@ return {
             ["pacespeed"] = 10,
             ["pacetype"] = "randomwander"
           }
+        },
+        {
+          id = 122,
+          name = "",
+          class = "",
+          shape = "rectangle",
+          x = 1060,
+          y = 580,
+          width = 40,
+          height = 40,
+          rotation = 0,
+          gid = 262,
+          visible = true,
+          properties = {}
         }
       }
     },

--- a/mods/_testmod/scripts/world/maps/alley4.tmx
+++ b/mods/_testmod/scripts/world/maps/alley4.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.9" tiledversion="1.9.0" orientation="orthogonal" renderorder="right-down" width="31" height="17" tilewidth="40" tileheight="40" infinite="0" nextlayerid="15" nextobjectid="121">
+<map version="1.9" tiledversion="1.9.0" orientation="orthogonal" renderorder="right-down" width="31" height="17" tilewidth="40" tileheight="40" infinite="0" nextlayerid="15" nextobjectid="123">
  <editorsettings>
   <export target="alley4.lua" format="lua"/>
  </editorsettings>
@@ -95,6 +95,7 @@
     <property name="pacetype" value="randomwander"/>
    </properties>
   </object>
+  <object id="122" gid="262" x="1060" y="580" width="40" height="40"/>
  </objectgroup>
  <layer id="13" name="Tile Layer 2" width="31" height="17">
   <data encoding="csv">

--- a/src/engine/game/world/chaserenemy.lua
+++ b/src/engine/game/world/chaserenemy.lua
@@ -23,7 +23,7 @@
 ---@field chase_accel   number  *[Property `chaseaccel`]* The acceleration of the enemy when chasing the player, in change of pixels per frame at 30FPS, or a multiplier of speed when in `multiplier` mode.
 ---
 ---@field pace_type     string  *[Property `pacetype`]* The type of pacing that the enemy will do while idling. See [PACETYPE](lua://PACETYPE) for available types.
----@field pace_marker   table   *[Property `marker`]* The name of a marker, or a list of markers (marker1, marker2, marker3, ...) that the enemy will pace between when `wander` pacing.
+---@field pace_marker   table   *[Property list `marker`]* The name of a marker, or a list of markers that the enemy will pace between when `wander` pacing.
 ---@field pace_interval number  *[Property `paceinterval`]* The interval between actions when `wander` pacing (Defaults to `24`)
 ---@field pace_return   boolean *[Property `pacereturn`]* Whether the enemy should return to its spawn point between every point when its `pace_type` is set to `wander` or `randomwander`. (Defaults to `true`)
 ---@field pace_speed    number  *[Property `pacespeed`]* The speed at which the enemy walks when `wander` pacing (Defaults to `2`)

--- a/src/engine/game/world/events/cameratarget.lua
+++ b/src/engine/game/world/events/cameratarget.lua
@@ -1,4 +1,26 @@
+--- A region in the Overworld that causes the camera to target a specific position while the player is inside. \
+--- `CameraTarget` is an [`Event`](lua://Event.init) - naming an object `cameratarget` on an `objects` layer in a map creates this object. \
+--- See this object's Fields for the configurable properties on this object.
+--- 
 ---@class CameraTarget : Event
+---
+---@field solid boolean
+---
+---@field target_x number       *[Property `x`]* The x-coordinate that the camera will center on 
+---@field target_y number       *[Property `y`]* The y-coordinate that the camera will center on
+---@field target_marker string  *[Property `marker`]* The marker that the camera will center on
+---
+---@field lock_x boolean        *[Property `lockx`]* Whether the camera's x position will be locked (Defaults to `true`)
+---@field lock_y boolean        *[Property `locky`]* Whether the camera's y position will be locked (Defaults to `true`)
+---
+---@field speed number          *[Property `speed`]* The speed at which the camera will move to its target position
+---@field return_speed number   *[Property `returnspeed`]* The speed at which the camera will return to its original target
+---
+---@field time number           *[Property `time`]* The time, in seconds, that the camera will take to move to its target position
+---@field return_time number    *[Property `returntime`]* The time, in seconds, that the camera will take to return to its original target
+---
+---@field entered boolean
+---
 ---@overload fun(...) : CameraTarget
 local CameraTarget, super = Class(Event)
 
@@ -23,6 +45,10 @@ function CameraTarget:init(x, y, w, h, properties)
     self.entered = false
 end
 
+--- Gets the target position of the camera whilst inside this region. \
+--- Priority is Marker > target position properties > center of object
+---@return number x
+---@return number y
 function CameraTarget:getTargetPosition()
     if self.target_marker then
         return self.world.map:getMarker(self.target_marker)

--- a/src/engine/game/world/events/controllers/togglecontroller.lua
+++ b/src/engine/game/world/events/controllers/togglecontroller.lua
@@ -1,4 +1,16 @@
+--- A controller that toggles the existence of events in maps in the Overworld. \
+--- Unlike load control properties such as `flagcheck` and `cond`, toggle immediately updates the loaded state of objects based on its flag, rather than requiring a room reload. \
+--- `ToggleController` is a `controller` - naming an object `toggle` on a `controllers` layer in a map creates this object. \
+--- See this object's Fields for the configurable properties on this object.
+--- 
 ---@class ToggleController : Event
+---
+---@field flag              string  *[Property `flag`]* The name of the flag to check for whether targets should be active - if `!` is at the start of the flag, the check will be [`inverted`](lua://ToggleController.inverted)
+---@field inverted          boolean *[Property `inverted`]* Whether the flagcheck is inverted such that if `flag` is `flag_value`, the controller targets are inactive, and active otherwise
+---@field flag_value        boolean *[Property `value`]* The value that `flag` should be for the controller targets to be active
+---
+---@field target_objs (Character|Event)[]   *[Property list `target`]* A list of objects that this controller is attached to
+---
 ---@overload fun(...) : ToggleController
 local ToggleController, super = Class(Event, "toggle")
 

--- a/src/engine/game/world/events/cybertrashcan.lua
+++ b/src/engine/game/world/events/cybertrashcan.lua
@@ -10,7 +10,7 @@
 ---@field money     number      *[Property `money`]* The amount of money contained in this treasure chest - cannot be used in conjunction with `item`
 ---
 ---@field set_flag  string      *[Property `setflag`]* An optional flag to set when the treasure chest is opened
----@field set_value any         *[Property `setvalue`]* The value to set on the flag specified by `setflag` (defaults to `true`)
+---@field set_value any         *[Property `setvalue`]* The value to set on the flag specified by `setflag` (Defaults to `true`)
 ---
 ---@overload fun(...) : CyberTrashCan
 local CyberTrashCan, super = Class(Event, "cybertrash")

--- a/src/engine/game/world/events/forcefield.lua
+++ b/src/engine/game/world/events/forcefield.lua
@@ -1,4 +1,22 @@
+--- Creates an electric forcefield that the player cannot pass through until a condition is met. \
+--- `Forcefield` is an [`Event`](lua://Event.init) - naming an object `forcefield` on an `objects` layer in a map creates this object. \
+--- See this object's Fields for the configurable properties on this object.
 ---@class Forcefield : Event
+---
+---@field end_sprite        love.Image[]
+---@field middle_sprite     love.Image[]
+---@field single_sprite     love.Image[]
+---
+---@field anim_speed        number  Speed of the forcefield animation, in seconds (Defaults to `3/30`)
+---@field anim_timer        number  Internal timer for the sprite animation
+---
+---@field solid             boolean *[Property `solid`]* Whether the forcefield is solid (Defaults to `true`)
+---@field always_visible    boolean *[Property `visible`]* Whether the forcefield is visible even when the player is not nearby (Defaults to `false`)
+---@
+---@field flag              string  *[Property `flag`]* The name of the flag to check for whether this forcefield is active - if `!` is at the start of the flag, the check will be [`inverted`](lua://Forcefield.inverted)
+---@field inverted          boolean *[Property `inverted`]* Whether the flagcheck is inverted such that if `flag` is `flag_value`, the forcefield is inactive, and is active otherwise
+---@field flag_value        boolean *[Property `value`]* The value that `flag` should be for the forcefield to be active
+---
 ---@overload fun(...) : Forcefield
 local Forcefield, super = Class(Event)
 

--- a/src/engine/game/world/events/forcefield.lua
+++ b/src/engine/game/world/events/forcefield.lua
@@ -12,7 +12,7 @@
 ---
 ---@field solid             boolean *[Property `solid`]* Whether the forcefield is solid (Defaults to `true`)
 ---@field always_visible    boolean *[Property `visible`]* Whether the forcefield is visible even when the player is not nearby (Defaults to `false`)
----@
+---
 ---@field flag              string  *[Property `flag`]* The name of the flag to check for whether this forcefield is active - if `!` is at the start of the flag, the check will be [`inverted`](lua://Forcefield.inverted)
 ---@field inverted          boolean *[Property `inverted`]* Whether the flagcheck is inverted such that if `flag` is `flag_value`, the forcefield is inactive, and is active otherwise
 ---@field flag_value        boolean *[Property `value`]* The value that `flag` should be for the forcefield to be active

--- a/src/engine/game/world/events/interactable.lua
+++ b/src/engine/game/world/events/interactable.lua
@@ -1,4 +1,25 @@
+--- Interactables are Overworld objects in Kristal that activate scripts, cutscenes, or text, when interacted with. \
+--- `Interactable` is an [`Event`](lua://Event.init) - naming an object `interactable` on an `objects` layer in a map creates this object. \
+--- See this object's Fields for the configurable properties on this object.
+---
 ---@class Interactable : Event
+---
+---@field solid     boolean *[Property `solid`]* Whether the interactable is solid
+---@
+---@field cutscene  string *[Property `cutscene`]* The name of a cutscene to start when interacting with this object
+---@field script    string *[Property `script`]* The name of a script file to execute when interacting with this object
+--- *[Property `text`]* A line of text to display when interacting with this object \
+--- *[Property list `text`]* Several lines of text to display when interacting with this object \
+--- *[Property multi-list `text`]* Several groups of lines of text to display on sequential interactions with this object - all of `text1_i` forms the first interaction, all of `text2_i` forms the second interaction etc...
+---@field text string[] 
+---
+---@field set_flag string   *[Property `setflag`]* The name of a flag to set the value of when interacting with this object
+---@field set_value any     *[Property `setvalue`]* The value to set the flag specified by [`set_flag`](lua://Interactable.set_flag) to (Defaults to `true`)
+---
+---@field once boolean      *[Property `once`]* Whether this event can only be interacted with once per save file (Defaults to `false`)
+---
+---@field interact_count number The number of times this interactable has been interacted with on this map load
+---
 ---@overload fun(...) : Interactable
 local Interactable, super = Class(Event)
 
@@ -76,6 +97,7 @@ function Interactable:onInteract(player, dir)
     return true
 end
 
+--- *(Override)* Called when the cutscene/text of this interactable finishes
 function Interactable:onTextEnd() end
 
 function Interactable:applyTileObject(data, map)

--- a/src/engine/game/world/events/interactable.lua
+++ b/src/engine/game/world/events/interactable.lua
@@ -5,7 +5,7 @@
 ---@class Interactable : Event
 ---
 ---@field solid     boolean *[Property `solid`]* Whether the interactable is solid
----@
+---
 ---@field cutscene  string *[Property `cutscene`]* The name of a cutscene to start when interacting with this object
 ---@field script    string *[Property `script`]* The name of a script file to execute when interacting with this object
 --- *[Property `text`]* A line of text to display when interacting with this object \

--- a/src/engine/game/world/events/magicglass.lua
+++ b/src/engine/game/world/events/magicglass.lua
@@ -1,4 +1,16 @@
+--- Magical glass are Overworld objects that appear only when stepped on. \
+--- `MagicGlass` is an [`Event`](lua://Event.init) - naming an object `magicglass` on an `objects` layer in a map creates this object.
 ---@class MagicGlass : Event
+---
+---@field texture           love.Image
+---@field tiles_x           integer
+---@field tiles_y           integer
+---
+---@field glass_colliders   Collider[]
+---@field tile_alphas       number[]
+---
+---@field collider          ColliderGroup
+---
 ---@overload fun(...) : MagicGlass
 local MagicGlass, super = Class(Event)
 

--- a/src/engine/game/world/events/npc.lua
+++ b/src/engine/game/world/events/npc.lua
@@ -1,4 +1,36 @@
+--- NPCs are an extension of Character that provide the ability to use them in the Overworld similar to an `Event`. \
+--- Naming an object `npc` on an `objects` layer in a map creates an NPC. \
+--- The actor used for an NPC can be set by defining an `actor` property and setting it to the id of the desired actor. \
+--- See this object's Fields for other configurable properties on this object.
+--- 
 ---@class NPC : Character
+---
+---@field idle_sprite string *[Property `sprite`]* The name of the sprite this NPC should use when idle
+---@field idle_animation string *[Property `animation`]* The name of the animation this NPC should use when idle
+---
+---@field start_facing string *[Property `facing`]* The direction the npc should be facing by default (Defaults to `"down"`)
+---
+---@field turn boolean *[Property `turn`]* Whether the NPC should turn to face the player when interacted with (Defaults to `false`)
+---
+---@field talk boolean *[Property `talk`]* Whether the npc should do a talking animation when interacted with and currently typing dialogue (Defaults to `true`)
+---@field talk_sprite string *[Property `talksprite`]* The name of a talk sprite to use for the NPC when talking
+---
+---@field solid boolean *[Property `solid`]* Whether the npc is solid (Defaults to `true`)
+---
+---@field cutscene  string *[Property `cutscene`]* The name of a cutscene to start when interacting with this npc
+---@field script    string *[Property `script`]* The name of a script file to execute when interacting with this npc
+--- *[Property `text`]* A line of text to display when interacting with this npc \
+--- *[Property list `text`]* Several lines of text to display when interacting with this npc \
+--- *[Property multi-list `text`]* Several groups of lines of text to display on sequential interactions with this npc - all of `text1_i` forms the first interaction, all of `text2_i` forms the second interaction etc...
+---@field text string[] 
+---
+---@field set_flag string   *[Property `setflag`]* The name of a flag to set the value of when interacting with this object
+---@field set_value any     *[Property `setvalue`]* The value to set the flag specified by [`set_flag`](lua://Interactable.set_flag) to (Defaults to `true`)
+---
+---@field interact_count number The number of times this npc has been interacted with on this map load
+---
+---@field interact_buffer number
+---
 ---@overload fun(...) : NPC
 local NPC, super = Class(Character)
 
@@ -78,6 +110,7 @@ function NPC:onInteract(player, dir)
     end
 end
 
+--- Resets the NPCs sprite to it's idle if it was talking, and turns it to face its original position
 function NPC:onTextEnd()
     if self.talk_sprite then
         if self.idle_sprite then

--- a/src/engine/game/world/events/pushblock.lua
+++ b/src/engine/game/world/events/pushblock.lua
@@ -1,4 +1,32 @@
+--- A Pushable Block! Collision for Pushblocks can be created by adding a `blockcollision` layer to a map. \
+--- `PushBlock` is an [`Event`](lua://Event.init) - naming an object `pushblock` on an `objects` layer in a map creates this object. \
+--- See this object's Fields for the configurable properties on this object.
+--- 
 ---@class PushBlock : Event
+---
+---@field default_sprite    string      *[Property `sprite`]* An optional custom sprite the block should use
+---@field solved_sprite     string      *[Property `solvedsprite`]* An optional custom solve sprite the block uses
+---
+---@field solid             boolean     
+---
+---@field push_dist         number      *[Property `pushdist`]* The number of pixels the block moves per push (Defaults to `40`, one tile)
+---@field push_timer        number      *[Property `pushtime`]* The time the block takes to complete a push, in seconds (Defaults to `0.2`)
+---
+---@field push_sound        string      *[Property `pushsound`]* The name of the sound file to play when the block is pushed (Defaults to `pushsound`)
+---
+---@field press_buttons     boolean     *[Property `pressbuttons`]* Unused (Defaults to `true`)
+---
+---@field lock_in_place     boolean     *[Property `lock`]* Whether the block gets locked in place when in a solved state (Defaults to `false`)
+---
+---@field input_lock        boolean     *[Property `inputlock`]* Whether the player's input's are locked while the block is being pushed
+---
+---@field start_x           number      Initial position of the block
+---@field start_y           number      Initial position of the block
+---
+---@field state             string      The current state of the Pushblock - value can be IDLE, PUSH, or RESET
+---
+---@field solved            boolean     Whether the pushblock is in a solved state
+---
 ---@overload fun(...) : PushBlock
 local PushBlock, super = Class(Event)
 
@@ -113,17 +141,22 @@ function PushBlock:onPush(facing)
     end)
 end
 
+--- *(Override)* Called when the block enters a solved state
 function PushBlock:onSolved()
     self:setSprite(self.solved_sprite)
 end
 
+--- *(Override)* Called when the block stops being in a solved state
 function PushBlock:onUnsolved()
     self:setSprite(self.default_sprite)
 end
 
+--- *(Override)* Called when a block finishes being pushed
 function PushBlock:onPushEnd(facing) end
+--- *(Override)* Called when a block cannot be pushed because of collision
 function PushBlock:onPushFail(facing) end
 
+--- Fades the block out and returns it to its original position
 function PushBlock:reset()
     if self.solved then
         self.solved = false
@@ -143,6 +176,7 @@ function PushBlock:reset()
     end)
 end
 
+--- *(Override)* Called when the block is reset
 function PushBlock:onReset() end
 
 return PushBlock

--- a/src/engine/game/world/events/savepoint.lua
+++ b/src/engine/game/world/events/savepoint.lua
@@ -1,4 +1,18 @@
+--- Savepoints allow the player to SAVE their game. \
+--- `Savepoint` is an [`Event`](lua://Event.init) - naming an object `savepoint` on an `objects` layer in a map creates this object. \
+--- See this object's Fields for the configurable properties on this object. The location displayed on the savefile is determined by the map's `name` property.
+--- 
 ---@class Savepoint : Interactable
+---
+---@field marker        string  *[Property `marker`]* The name of the marker that the party should spawn at when a save from here is loaded
+---@field simple_menu   boolean *[Property `simple`]* Whether this Savepoint uses the Simple (one slot, no storage/recruits) save menu
+---@field text_once     boolean *[Prpoerty `text_once`]* Whether this Savepoint doesn't display its text on repeat interactions (Defaults to `false`)
+---@field heals         boolean *[Property `heals`]* Whether this Savepoint heals the party when interacted with (Defaults to `true`)
+---
+---@field solid         boolean
+---
+---@field used          boolean
+---
 ---@overload fun(...) : Savepoint
 local Savepoint, super = Class(Interactable)
 

--- a/src/engine/game/world/events/script.lua
+++ b/src/engine/game/world/events/script.lua
@@ -1,4 +1,19 @@
+--- Scripts are Overworld events that trigger immediately when the player steps into them. \
+--- Naming an object `script` on an `objects` layer in a map creates this object. \
+--- See this object's Fields for the configurable properties on this object.
 ---@class Script : Event
+---
+---@field solid     boolean
+---
+---@field cutscene  string  *[Property `cutscene`]* The name of a cutscene to start when this script is triggered
+---@field script    string  *[Property `script`]* The name of a script file to run when this script is triggered
+---
+---@field set_flag  string  *[Property `setflag`]* The name of a flag to set the value of when this script is triggered 
+---@field set_value any     *[Property `setvalue`]* The value to set on the flag specified by [`set_flag`](lua://Script.set_flag) (Defaults to `true`)
+---@
+---@field once      boolean *[Property `once`]* Whether this script can only be triggered once per save file (Defaults to `true`)
+---@field temp      boolean *[Property `temp`]* Whether the script is temporarily persistent - appears even if `once` is true and it has been triggered (Defaults to `false`)
+---
 ---@overload fun(...) : Script
 local Script, super = Class(Event)
 

--- a/src/engine/game/world/events/script.lua
+++ b/src/engine/game/world/events/script.lua
@@ -10,7 +10,7 @@
 ---
 ---@field set_flag  string  *[Property `setflag`]* The name of a flag to set the value of when this script is triggered 
 ---@field set_value any     *[Property `setvalue`]* The value to set on the flag specified by [`set_flag`](lua://Script.set_flag) (Defaults to `true`)
----@
+---
 ---@field once      boolean *[Property `once`]* Whether this script can only be triggered once per save file (Defaults to `true`)
 ---@field temp      boolean *[Property `temp`]* Whether the script is temporarily persistent - appears even if `once` is true and it has been triggered (Defaults to `false`)
 ---

--- a/src/engine/game/world/events/setflagevent.lua
+++ b/src/engine/game/world/events/setflagevent.lua
@@ -1,4 +1,13 @@
+--- An Overworld region that sets a flag when the player steps into it. \
+--- `SetFlagEvent` is an [`Event`](lua://Event.init) - naming an object `setflag` on an `objects` layer in a map creates this object. \
+--- See this object's Fields for the configurable properties on this object.
 ---@class SetFlagEvent : Event
+---
+---@field flag      string      *[Property `flag`]* The name of the flag to set a value on
+---@field value     any         *[Property `value`]* The value to set on the flag
+---@field once      boolean     *[Property `once`]* Whether the flag can only be set by this region once (Defaults to `false`)
+---@field map_flag  string      *[Property `mapflag`]* The name of the flag to set a value on, only affecting the current map
+---
 ---@overload fun(...) : SetFlagEvent
 local SetFlagEvent, super = Class(Event, "setflag")
 

--- a/src/engine/game/world/events/silhouette.lua
+++ b/src/engine/game/world/events/silhouette.lua
@@ -1,4 +1,9 @@
+--- A region in the Overworld that draws silhouettes of character's inside it that draw on top of the world. The original characters are not hidden. \
+--- `Silhouette` is an [`Event`](lua://Event.init) - naming an object `silhouette` on an `objects` layer in a map creates this object. \
 ---@class Silhouette : Event
+---
+---@field solid boolean
+---
 ---@overload fun(...) : Silhouette
 local Silhouette, super = Class(Event)
 

--- a/src/engine/game/world/events/slidearea.lua
+++ b/src/engine/game/world/events/slidearea.lua
@@ -1,4 +1,12 @@
+--- SlideAreas cause the party to slide down them when entered. \
+--- `SlideArea` is an [`Event`](lua://Event.init) - naming an object `slidearea` on an `objects` layer in a map creates this object. \
+--- See this object's Fields for the configurable properties on this object.
 ---@class SlideArea : Event
+---
+---@field lock_movement boolean *[Property `lock`]* Whether the player's movement is locked while sliding (Defaults to `false`)
+---
+---@field solid boolean
+---
 ---@overload fun(...) : SlideArea
 local SlideArea, super = Class(Event)
 

--- a/src/engine/game/world/events/tilebutton.lua
+++ b/src/engine/game/world/events/tilebutton.lua
@@ -1,4 +1,31 @@
+--- A button that either characters or [`PushBlock`s](lua://PushBlock.init) can activate. \
+--- `TileButton` is an [`Event`](lua://Event.init) - naming an object `tilebutton` on an `objects` layer in a map creates this object. \
+--- See this object's Fields for the configurable properties on this object.
+--- 
 ---@class TileButton : Event
+---
+---@field idle_sprite       string  *[Property `sprite`]* An optional custom sprite to use for this TileButton
+---@field pressed_sprite    string  *[Property `pressedsprite`]* An optional custom sprite to use for this TileButton when it is pressed down
+---
+---@field on_sound          string  *[Property `onsound`]* The sound file that plays when this button is pressed down
+---@field off_sound         string  *[Property `offsound`]* The sound file that plays when this button stops being pressed down
+---
+---@field npc_activated     boolean *[Property `blocks`]* Whether this button is activated by blocks or players and npcs (Defaults to `true` - players and npcs)
+---@field player_activated  boolean *[Property `blocks`]* Whether this button is activated by blocks or players and npcs (Defaults to `true` - players and npcs)
+---@field block_activated   boolean *[Property `blocks`]* Whether this button is activated by blocks or players and npcs (Defaults to `false` - players and npcs)
+---
+---@field group             string|number *[Property `group`]* When this value is the same for mutliple tile buttons in one room, they are grouped together, and will not be marked as completed/solved until all of them are pressed simultaneously
+---
+---@field flag              string  *[Property `flag`]* The name of a flag to set to `true` when the button's group is solved
+---@field once              boolean *[Property `once`]* Whether the tile button's puzzle can only be solved once per save file
+---
+---@field keep_down         boolean *[Property `keepdown`]* Whether the button should remain pressed even when the object pressing it moves away (Defaults to `false`)
+---
+---@field cutscene          string  *[Property `cutscene`]* The name of a cutscene that should play when the button's puzzle is solved
+---@field script            string  *[Property `script`]* The name of a script file that should be executed when the button's puzzle is solved
+---
+---@field pressed           boolean Whether the button is currently pressed down
+---
 ---@overload fun(...) : TileButton
 local TileButton, super = Class(Event)
 
@@ -63,6 +90,9 @@ function TileButton:update()
     super.update(self)
 end
 
+--- Changes the pressed state of the button and checks for completion of its puzzle
+---@param pressed boolean
+---@return boolean
 function TileButton:setPressed(pressed)
     if self.pressed == pressed then return false end
 
@@ -79,6 +109,7 @@ function TileButton:setPressed(pressed)
     end
 end
 
+--- Called whenever the button is pressed, setting its sprite and playing the press sound
 function TileButton:onPressed()
     self:setSprite(self.pressed_sprite)
     if self.on_sound and self.on_sound ~= "" then
@@ -86,6 +117,7 @@ function TileButton:onPressed()
     end
 end
 
+--- Called whenever the button is released, playing its idle sprite at 6fps (`5/30` seconds speed), and playing the release sound
 function TileButton:onReleased()
     self:setSprite(self.idle_sprite, 5/30)
     if self.off_sound and self.off_sound ~= "" then
@@ -93,6 +125,7 @@ function TileButton:onReleased()
     end
 end
 
+--- Called to run everything that happens when the tile button puzzle is completed
 function TileButton:onCompleted()
     self:setFlag("solved", true)
 
@@ -108,6 +141,7 @@ function TileButton:onCompleted()
     end
 end
 
+--- Called to set the tile button puzzle as incomplete
 function TileButton:onIncompleted()
     self:setFlag("solved", false)
 
@@ -116,6 +150,7 @@ function TileButton:onIncompleted()
     end
 end
 
+--- Checks whether the tile button puzzle is completed and then calls [`onCompleted()`](lua://TileButton.onCompleted) or [`onIncompleted()`](lua://TileButton.onIncompleted) appropriately.
 function TileButton:checkCompletion()
     if not self.group then
         if self.pressed and not self:getFlag("solved") then

--- a/src/engine/game/world/events/tileobject.lua
+++ b/src/engine/game/world/events/tileobject.lua
@@ -1,7 +1,26 @@
+--- A combination of a tile from a tileset and an Event. \
+--- TileObject is not a standard event - it defines no properties and is placed in a map using the `Insert Tile` feature through Tiled, rather than as an object.
+--- 
 ---@class TileObject : Event
----@overload fun(...) : TileObject
+---
+---@field tileset Tileset       The name of the tileset the tile is from
+---@field tile number           The gid of the tile in its tileset
+---@field rotation number?      The rotation of the tile
+---@field tile_flip_x boolean?  Whether the tile is flipped on its x-axis
+---@field tile_flip_y boolean?  Whether the tile is flipped on its y-axis
+---
+---@overload fun(tileset: Tileset, tile: number, x: number, y: number, w?: number, h?: number, rotation?: number, flip_x?: boolean, flip_y?: boolean) : TileObject
 local TileObject, super = Class(Event)
 
+---@param tileset Tileset
+---@param tile number
+---@param x number
+---@param y number
+---@param w? number
+---@param h? number
+---@param rotation? number
+---@param flip_x? boolean
+---@param flip_y? boolean
 function TileObject:init(tileset, tile, x, y, w, h, rotation, flip_x, flip_y)
     local tile_width, tile_height = tileset:getTileSize(tile)
 

--- a/src/engine/game/world/events/transition.lua
+++ b/src/engine/game/world/events/transition.lua
@@ -15,12 +15,12 @@
 --- *[Property `facing`]* The direction the player and party should face when they spawn in the new map 
 ---@field target {map: string, shop: string, x: number, y: number, marker: string, facing: string} 
 ---
----@field sound string? An optional sound to play when the player activates this transition
----@field pitch number  The pitch the entry sound should play at
+---@field sound string? *[Property `sound`]* An optional sound to play when the player activates this transition
+---@field pitch number  *[Property `pitch`]* The pitch the entry sound should play at
 ---
----@field exit_delay number     Additional delay after entering the new map before playing the exit sound, in seconds (defaults to `0`)
----@field exit_sound string?    An optional sound to play when entering the new map
----@field exit_pitch number     The pitch the exit sound should play at
+---@field exit_delay number     *[Property `exit_delay`]* Additional delay after entering the new map before playing the exit sound, in seconds (Defaults to `0`)
+---@field exit_sound string?    *[Property `exit_sound`]* An optional sound to play when entering the new map
+---@field exit_pitch number     *[Property `exit_pitch`]* The pitch the exit sound should play at
 ---
 ---@overload fun(...) : Transition
 local Transition, super = Class(Event)

--- a/src/engine/game/world/events/treasurechest.lua
+++ b/src/engine/game/world/events/treasurechest.lua
@@ -11,7 +11,7 @@
 ---@field money     number      *[Property `money`]* The amount of money contained in this treasure chest - cannot be used in conjunction with `item`
 ---
 ---@field set_flag  string      *[Property `setflag`]* An optional flag to set when the treasure chest is opened
----@field set_value any         *[Property `setvalue`]* The value to set on the flag specified by `setflag` (defaults to `true`)
+---@field set_value any         *[Property `setvalue`]* The value to set on the flag specified by `setflag` (Defaults to `true`)
 ---
 ---@overload fun(...) : TreasureChest
 local TreasureChest, super = Class(Event, "chest")

--- a/src/engine/game/world/events/warpdoor.lua
+++ b/src/engine/game/world/events/warpdoor.lua
@@ -11,10 +11,10 @@
 ---@field open          boolean     *[Property `open`]* Whether the door is open (defaults to `true`)
 ---@field open_flag     string      *[Property `openflag`]* The name of a flag that will be used to control the state of the door
 ---
----@field maps          table       *[Property list `map`]* A list of available maps to travel to
----@field names         table       *[Property list `name`]* A list of display names for each map in the warp choice
----@field markers       table       *[Property list `marker`]* A list of markers used when warping to each map
----@field flags         table       *[Property list `flag`]* A list of flags checked to decide whether a map can be warped to
+---@field maps          string[]    *[Property list `map`]* A list of available maps to travel to
+---@field names         string[]    *[Property list `name`]* A list of display names for each map in the warp choice
+---@field markers       string[]    *[Property list `marker`]* A list of markers used when warping to each map
+---@field flags         string[]    *[Property list `flag`]* A list of flags checked to decide whether a map can be warped to
 ---
 ---@overload fun(...) : WarpDoor
 local WarpDoor, super = Class(Event, "warpdoor")

--- a/src/engine/game/world/events/warpdoor.lua
+++ b/src/engine/game/world/events/warpdoor.lua
@@ -8,7 +8,7 @@
 ---@field collider      Collider
 ---@field light         Sprite      Sprite instance for the light that appears under an active door
 ---
----@field open          boolean     *[Property `open`]* Whether the door is open (defaults to `true`)
+---@field open          boolean     *[Property `open`]* Whether the door is open (Defaults to `true`)
 ---@field open_flag     string      *[Property `openflag`]* The name of a flag that will be used to control the state of the door
 ---
 ---@field maps          string[]    *[Property list `map`]* A list of available maps to travel to

--- a/src/engine/game/world/events/warpdoor.lua
+++ b/src/engine/game/world/events/warpdoor.lua
@@ -1,4 +1,21 @@
+--- Warp Doors allow for fast travel between Overworld locations. \
+--- `WarpDoor` is an [`Event`](lua://Event.init) - naming an object `warpdoor` on an `objects` layer in a map creates this object. \
+--- See this object's Fields for the configurable properties on this object.
+--- 
 ---@class WarpDoor : Event
+---
+---@field solid         boolean
+---@field collider      Collider
+---@field light         Sprite      Sprite instance for the light that appears under an active door
+---
+---@field open          boolean     *[Property `open`]* Whether the door is open (defaults to `true`)
+---@field open_flag     string      *[Property `openflag`]* The name of a flag that will be used to control the state of the door
+---
+---@field maps          table       *[Property list `map`]* A list of available maps to travel to
+---@field names         table       *[Property list `name`]* A list of display names for each map in the warp choice
+---@field markers       table       *[Property list `marker`]* A list of markers used when warping to each map
+---@field flags         table       *[Property list `flag`]* A list of flags checked to decide whether a map can be warped to
+---
 ---@overload fun(...) : WarpDoor
 local WarpDoor, super = Class(Event, "warpdoor")
 
@@ -91,6 +108,7 @@ function WarpDoor:onInteract(chara, facing)
     return true
 end
 
+--- Updates the state of the door based on its `open_flag`, and accordingly adjusts it's own sprite and its [`light`](lua://WarpDoor.light)
 function WarpDoor:updateOpen()
     self.open = Game:getFlag(self.open_flag)
     if self.open then


### PR DESCRIPTION
All events that were not previously documented should now have documentation!
While the event documentations are now rounded up, it is worth noting that the ability to put `Sprite`s in maps like events is not documented yet, and the globally applied custom properties for loading, `flagcheck` and `cond` aren't yet documented anywhere either