### PR TITLE
Instant quit option for leaving mods

### DIFF
--- a/src/engine/menu/mainmenuoptions.lua
+++ b/src/engine/menu/mainmenuoptions.lua
@@ -615,6 +615,7 @@ function MainMenuOptions:initializeOptions()
     self:registerConfigOption("engine", "Verbose Loader", "verboseLoader")
     self:registerConfigOption("engine", "Use System Mouse", "systemCursor", function () Kristal.updateCursor() end)
     self:registerConfigOption("engine", "Always Show Mouse", "alwaysShowCursor", function () Kristal.updateCursor() end)
+    self:registerConfigOption("engine", "Instant Quit", "instantQuit")
 end
 
 return MainMenuOptions

--- a/src/engine/overlay.lua
+++ b/src/engine/overlay.lua
@@ -49,22 +49,35 @@ function Overlay:update()
     end
 
     if love.keyboard.isDown("escape") and not self.quit_release then
-        if self.quit_alpha < 1 then
-            self.quit_alpha = math.min(1, self.quit_alpha + DT / 0.75)
-        end
-        self.quit_timer = self.quit_timer + DT
-        if self.quit_timer > 1.2 then
-            if Mod ~= nil then
-                self.quit_release = true
-                if Kristal.getModOption("hardReset") then
-                    love.event.quit("restart")
-                else
-                    Kristal.returnToMenu()
-                end
-            else
-                love.event.quit()
-            end
-        end
+		if Kristal.Config and Kristal.Config["instantQuit"] then
+			if Mod ~= nil then
+				self.quit_release = true
+				if Kristal.getModOption("hardReset") then
+					love.event.quit("restart")
+				else
+					Kristal.returnToMenu()
+				end
+			else
+				love.event.quit()
+			end
+		else
+			if self.quit_alpha < 1 then
+				self.quit_alpha = math.min(1, self.quit_alpha + DT / 0.75)
+			end
+			self.quit_timer = self.quit_timer + DT
+			if self.quit_timer > 1.2 then
+				if Mod ~= nil then
+					self.quit_release = true
+					if Kristal.getModOption("hardReset") then
+						love.event.quit("restart")
+					else
+						Kristal.returnToMenu()
+					end
+				else
+					love.event.quit()
+				end
+			end
+		end
     else
         self.quit_timer = 0
         if self.quit_alpha > 0 then


### PR DESCRIPTION
If this is enabled, you only have to press the "escape" key to exit the mod, rather than hold it. Defaults to being disabled.