### PR TITLE
[FIX] the window freeze when open mods folder on win11

### DIFF
--- a/src/engine/menu/mainmenucredits.lua
+++ b/src/engine/menu/mainmenucredits.lua
@@ -57,7 +57,7 @@ function MainMenuCredits:init(menu)
                 "WIL-TZY",
                 "TFLTV",
                 "J.A.R.U.",
-                "",
+                "MCdeDaxia",
                 "",
                 ""
             },

--- a/src/engine/menu/mainmenutitle.lua
+++ b/src/engine/menu/mainmenutitle.lua
@@ -78,7 +78,11 @@ function MainMenuTitle:onKeyPressed(key, is_repeat)
             end
 
         elseif option == "modfolder" then
-            love.system.openURL("file://"..love.filesystem.getSaveDirectory().."/mods")
+            if (love.system.getOS() == "Windows") then
+                os.execute("start /B "..love.filesystem.getSaveDirectory().."/mods")
+            else
+                love.system.openURL("file://"..love.filesystem.getSaveDirectory().."/mods")
+            end
 
         elseif option == "options" then
             self.menu:setState("OPTIONS")

--- a/src/engine/menu/mainmenutitle.lua
+++ b/src/engine/menu/mainmenutitle.lua
@@ -78,6 +78,7 @@ function MainMenuTitle:onKeyPressed(key, is_repeat)
             end
 
         elseif option == "modfolder" then
+            -- FIXME: the game might freeze when using love.system.openURL to open a file directory
             if (love.system.getOS() == "Windows") then
                 os.execute("start /B "..love.filesystem.getSaveDirectory().."/mods")
             else


### PR DESCRIPTION
Use `os.execute` to open the mods directory.
If it's not on windows the code will fallback to the original plan.

This is because when I play on windows11, the game stucks **mostly** when I use the 'open mods folder' and it's annoying.