### PR TITLE
Add pages to the keybinds menu for each mod's keybinds

### DIFF
--- a/src/engine/input.lua
+++ b/src/engine/input.lua
@@ -77,7 +77,7 @@ Input.gamepad_cursor_x = (love.graphics.getWidth()  / 2) - (Input.gamepad_cursor
 Input.gamepad_cursor_y = (love.graphics.getHeight() / 2) - (Input.gamepad_cursor_size / 2)
 
 Input.order = {
-    "down", "right", "up", "left", "confirm", "cancel", "menu", "console", "debug_menu", "object_selector", "fast_forward"
+    "down", "right", "up", "left", "confirm", "cancel", "menu", "console", "debug_menu", "object_selector", "fast_forward", "mod_rebind"
 }
 
 Input.required_binds = {
@@ -202,7 +202,8 @@ function Input.resetBinds(gamepad, mod_id)
             ["console"] = {"`"},
             ["debug_menu"] = {{"shift", "`"}},
             ["object_selector"] = {{"ctrl", "o"}},
-            ["fast_forward"] = {{"ctrl", "g"}}
+            ["fast_forward"] = {{"ctrl", "g"}},
+            ["mod_rebind"] = {"/"},
         }
         local gamepad_bindings = {
             ["up"] = {"gamepad:dpup", "gamepad:lsup"},
@@ -216,6 +217,7 @@ function Input.resetBinds(gamepad, mod_id)
             ["debug_menu"] = {},
             ["object_selector"] = {},
             ["fast_forward"] = {},
+            ["mod_rebind"] = {},
         }
         if gamepad ~= true then Utils.merge(Input.key_bindings, key_bindings) end
         if gamepad ~= false then Utils.merge(Input.gamepad_bindings, gamepad_bindings) end
@@ -265,7 +267,8 @@ function Input.resetBinds(gamepad, mod_id)
             ["console"] = {"`"},
             ["debug_menu"] = {{"shift", "`"}},
             ["object_selector"] = {{"ctrl", "o"}},
-            ["fast_forward"] = {{"ctrl", "g"}}
+            ["fast_forward"] = {{"ctrl", "g"}},
+            ["mod_rebind"] = {"/"},
         }
         for _,mod in ipairs(Kristal.Mods.getMods()) do
             if mod.keybinds then
@@ -311,6 +314,7 @@ function Input.resetBinds(gamepad, mod_id)
             ["debug_menu"] = {},
             ["object_selector"] = {},
             ["fast_forward"] = {},
+            ["mod_rebind"] = {},
         }
         for _,mod in ipairs(Kristal.Mods.getMods()) do
             if mod.keybinds then

--- a/src/engine/input.lua
+++ b/src/engine/input.lua
@@ -187,7 +187,70 @@ function Input.getBoundKeys(key, gamepad)
 end
 
 ---@param gamepad? boolean
-function Input.resetBinds(gamepad)
+---@param mod_id? string
+function Input.resetBinds(gamepad, mod_id)
+    -- Special id to reset only default Kristal keybinds
+    if mod_id == "KRISTAL" then
+        local key_bindings = {
+            ["up"] = {"up"},
+            ["down"] = {"down"},
+            ["left"] = {"left"},
+            ["right"] = {"right"},
+            ["confirm"] = {"z", "return"},
+            ["cancel"] = {"x", "shift"},
+            ["menu"] = {"c", "ctrl"},
+            ["console"] = {"`"},
+            ["debug_menu"] = {{"shift", "`"}},
+            ["object_selector"] = {{"ctrl", "o"}},
+            ["fast_forward"] = {{"ctrl", "g"}}
+        }
+        local gamepad_bindings = {
+            ["up"] = {"gamepad:dpup", "gamepad:lsup"},
+            ["down"] = {"gamepad:dpdown", "gamepad:lsdown"},
+            ["left"] = {"gamepad:dpleft", "gamepad:lsleft"},
+            ["right"] = {"gamepad:dpright", "gamepad:lsright"},
+            ["confirm"] = {"gamepad:a"},
+            ["cancel"] = {"gamepad:b"},
+            ["menu"] = {"gamepad:y"},
+            ["console"] = {},
+            ["debug_menu"] = {},
+            ["object_selector"] = {},
+            ["fast_forward"] = {},
+        }
+        if gamepad ~= true then Utils.merge(Input.key_bindings, key_bindings) end
+        if gamepad ~= false then Utils.merge(Input.gamepad_bindings, gamepad_bindings) end
+        return
+    -- If we receive a mod id, we are only resetting binds specific to that mod
+    elseif mod_id then
+        local mod = Kristal.Mods.getMod(mod_id)
+        if not mod then return end
+        local keys = mod.keybinds or {}
+        local libs = mod.libs or {}
+        for _, lib in pairs(libs) do
+            if lib.keybinds then Utils.merge(keys, lib.keybinds) end
+        end
+        if keys == {} then return end
+        if gamepad ~= true then
+            for _, v in pairs(keys) do
+                if v.keys then
+                    Input.key_bindings[v.id] = Utils.copy(v.keys)
+                else
+                    Input.key_bindings[v.id] = {}
+                end
+            end
+        end
+        if gamepad ~= false then
+            for _, v in pairs(keys) do
+                if v.gamepad then
+                    Input.gamepad_bindings[v.id] = Utils.copy(v.gamepad)
+                else
+                    Input.gamepad_bindings[v.id] = {}
+                end
+            end
+        end
+        return
+    end
+
     if gamepad ~= true then
         Input.mod_keybinds = {}
         Input.stray_key_bindings = {}

--- a/src/engine/input.lua
+++ b/src/engine/input.lua
@@ -23,6 +23,8 @@
 ---@field stray_key_bindings table<string, (string|string[])[]>
 ---@field stray_gamepad_bindings table<string, (string|string[])[]>
 ---
+---@field mod_keybinds table<string, string[]>
+---
 ---@field gamepad_locked boolean
 ---
 ---@field gamepad_cursor_size number
@@ -65,6 +67,8 @@ Input.gamepad_bindings = {}
 
 Input.stray_key_bindings = {}
 Input.stray_gamepad_bindings = {}
+
+Input.mod_keybinds = {}
 
 Input.gamepad_locked = false
 
@@ -185,6 +189,7 @@ end
 ---@param gamepad? boolean
 function Input.resetBinds(gamepad)
     if gamepad ~= true then
+        Input.mod_keybinds = {}
         Input.stray_key_bindings = {}
         Input.key_bindings = {
             ["up"] = {"up"},
@@ -201,9 +206,11 @@ function Input.resetBinds(gamepad)
         }
         for _,mod in ipairs(Kristal.Mods.getMods()) do
             if mod.keybinds then
+                Input.mod_keybinds[mod.id] = {}
                 for _,v in pairs(mod.keybinds) do
                     if v.keys then
                         Input.key_bindings[v.id] = Utils.copy(v.keys)
+                        table.insert(Input.mod_keybinds[mod.id], v.id)
                     else
                         Input.key_bindings[v.id] = {}
                     end
@@ -212,9 +219,11 @@ function Input.resetBinds(gamepad)
             if mod.libs then
                 for _,lib in pairs(mod.libs) do
                     if lib.keybinds then
+                        Input.mod_keybinds[mod.id] = Input.mod_keybinds[mod.id] or {}
                         for _,v in pairs(lib.keybinds) do
                             if v.keys then
                                 Input.key_bindings[v.id] = Utils.copy(v.keys)
+                                table.insert(Input.mod_keybinds[mod.id], v.id)
                             else
                                 Input.key_bindings[v.id] = {}
                             end

--- a/src/engine/menu/mainmenucontrols.lua
+++ b/src/engine/menu/mainmenucontrols.lua
@@ -26,6 +26,11 @@ function MainMenuControls:init(menu)
 
     self.control_menu = "keyboard"
 
+    self.pages = {}
+    self:registerMainPage()
+    self:registerModPages()
+    self.selected_page = 1
+
     self.selected_option = 1
     self.selected_bind = 1
 
@@ -39,6 +44,9 @@ function MainMenuControls:init(menu)
 
     self.scroll_target_y = 0
     self.scroll_y = 0
+
+    self.scroll_direction = "right"
+    self.scroll_timer = 0
 end
 
 function MainMenuControls:registerEvents()
@@ -47,6 +55,37 @@ function MainMenuControls:registerEvents()
     self:registerEvent("keyreleased", self.onKeyReleased)
     self:registerEvent("update", self.update)
     self:registerEvent("draw", self.draw)
+end
+
+function MainMenuControls:registerMainPage()
+    local page = {}
+
+    page.title = "KRISTAL"
+    page.mod = "KRISTAL"
+    page.entries = {}
+
+    for _, keybind in ipairs(Input.order) do
+        table.insert(page.entries, {keybind = keybind, name = (Input.getBindName(keybind) or keybind:gsub("_", " ")):upper()})
+    end
+
+    table.insert(self.pages, page)
+end
+
+function MainMenuControls:registerModPages()
+    for mod_id, keys in pairs(Input.mod_keybinds) do
+        local page = {}
+        local mod = Kristal.Mods.getMod(mod_id)
+
+        page.title = tostring(mod.name):upper()
+        page.mod = mod_id
+        page.entries = {}
+
+        for _, keybind in ipairs(keys) do
+            table.insert(page.entries, {keybind = keybind, name = (Input.getBindName(keybind) or keybind:gsub("_", " ")):upper()})
+        end
+
+        table.insert(self.pages, page)
+    end
 end
 
 -------------------------------------------------------------------------------
@@ -58,6 +97,7 @@ function MainMenuControls:onEnter(old_state, control_menu)
 
     self.selected_option = 1
     self.selected_bind = 1
+    self.selected_page = 1
 
     self.selecting_key = false
     self.rebinding = false
@@ -70,28 +110,52 @@ function MainMenuControls:onEnter(old_state, control_menu)
     self.scroll_target_y = 0
     self.scroll_y = 0
 
+    self.scroll_direction = "right"
+    self.scroll_timer = 0
+
     self.menu.heart_target_x = 152
     self.menu.heart_target_y = 129 + 0 * 32
 end
 
 function MainMenuControls:onKeyPressed(key, is_repeat)
     if (not self.rebinding) and (not self.selecting_key) then
+        local selected_page = self:getSelectedPage()
         local bind_list = self.control_menu == "gamepad" and Input.gamepad_bindings or Input.key_bindings
-        local option_count = Utils.tableLength(bind_list) + 2
+        local option_count = Utils.tableLength(selected_page.entries) + 2
+        local page_count = #self.pages
         if self.control_menu == "gamepad" then
             option_count = option_count + 1
         end
 
-        local old = self.selected_option
+        local old_selected = self.selected_option
         if Input.is("up"   , key)                              then self.selected_option = self.selected_option - 1 end
         if Input.is("down" , key)                              then self.selected_option = self.selected_option + 1 end
-        if Input.is("left" , key) and not Input.usingGamepad() then self.selected_option = self.selected_option - 1 end
-        if Input.is("right", key) and not Input.usingGamepad() then self.selected_option = self.selected_option + 1 end
         if self.selected_option < 1            then self.selected_option = is_repeat and 1 or option_count end
         if self.selected_option > option_count then self.selected_option = is_repeat and option_count or 1 end
 
-        if old ~= self.selected_option then
+        local old_page = self.selected_page
+        local page_dir = "right"
+        if Input.is("left" , key) and not Input.usingGamepad() then self.selected_page = self.selected_page - 1; page_dir = "left" end
+        if Input.is("right", key) and not Input.usingGamepad() then self.selected_page = self.selected_page + 1; page_dir = "right" end
+        if self.selected_page < 1          then self.selected_page = is_repeat and 1 or page_count end
+        if self.selected_page > page_count then self.selected_page = is_repeat and page_count or 1 end
+
+        if old_selected ~= self.selected_option then
             Assets.stopAndPlaySound("ui_move")
+        end
+
+        if old_page ~= self.selected_page then
+            Assets.stopAndPlaySound("ui_move")
+            selected_page = self:getSelectedPage()
+            option_count = Utils.tableLength(selected_page.entries) + 2
+            if self.control_menu == "gamepad" then
+                option_count = option_count + 1
+            end
+
+            self.selected_option = 1
+
+            self.scroll_direction = page_dir
+            self.scroll_timer = 0.1
         end
 
         if Input.isCancel(key) then
@@ -103,7 +167,7 @@ function MainMenuControls:onKeyPressed(key, is_repeat)
             self.selecting_key = false
              -- Reset to Defaults
             if (self.selected_option == option_count - 1) then
-                Input.resetBinds(self.control_menu == "gamepad")
+                Input.resetBinds(self.control_menu == "gamepad", selected_page.mod)
                 Assets.stopAndPlaySound("ui_select")
                 self.selected_option = option_count - 1
                 self.menu.heart_target_y = (129 + (self.selected_option) * 32) + self.scroll_target_y
@@ -124,7 +188,7 @@ function MainMenuControls:onKeyPressed(key, is_repeat)
             end
         end
     elseif self.selecting_key then
-        local table_key = Input.orderedNumberToKey(self.selected_option)
+        local table_key = self:getSelectedKey()
 
         local old = self.selected_bind
         if Input.is("left" , key) then self.selected_bind = self.selected_bind - 1 end
@@ -183,7 +247,7 @@ function MainMenuControls:onKeyPressed(key, is_repeat)
 
             if valid_key then
                 -- rebind!!
-                local worked = Input.setBind(Input.orderedNumberToKey(self.selected_option), self.selected_bind, bound_key, self.control_menu == "gamepad")
+                local worked = Input.setBind(self:getSelectedKey(), self.selected_bind, bound_key, self.control_menu == "gamepad")
 
                 self.rebinding = false
                 self.rebinding_shift = false
@@ -225,7 +289,7 @@ function MainMenuControls:onKeyReleased(key)
             end
 
             -- rebind!!
-            local worked = Input.setBind(Input.orderedNumberToKey(self.selected_option), self.selected_bind, bound_key, self.control_menu == "gamepad")
+            local worked = Input.setBind(self:getSelectedKey(), self.selected_bind, bound_key, self.control_menu == "gamepad")
 
             self.rebinding = false
             self.rebinding_shift = false
@@ -247,10 +311,10 @@ end
 
 function MainMenuControls:update()
     -- Update heart position
-    local bind_list = self.control_menu == "gamepad" and Input.gamepad_bindings or Input.key_bindings
+    local selected_page = self.pages[self.selected_page]
 
     local y_off = (self.selected_option - 1) * 32
-    if self.selected_option > (Utils.tableLength(bind_list)) then
+    if self.selected_option > (Utils.tableLength(selected_page.entries)) then
         y_off = y_off + 32
     end
 
@@ -274,22 +338,32 @@ function MainMenuControls:update()
         self.scroll_y = self.scroll_target_y
     end
     self.scroll_y = self.scroll_y + ((self.scroll_target_y - self.scroll_y) / 2) * DTMULT
+    
+    if self.scroll_timer > 0 then
+        self.scroll_timer = Utils.approach(self.scroll_timer, 0, DT)
+    end
 end
 
 function MainMenuControls:draw()
-    love.graphics.setFont(Assets.getFont("main"))
+    local selected_page = self:getSelectedPage()
+    local font = Assets.getFont("main")
+
+    love.graphics.setFont(font)
     Draw.setColor(COLORS.silver)
     Draw.printShadow("( OPTIONS )", 0, 0, 2, "center", 640)
 
     Draw.setColor(1, 1, 1)
     Draw.printShadow(""..self.control_menu:upper().." CONTROLS", 0, 48, 2, "center", 640)
+    Draw.setColor(COLORS.silver)
+    Draw.printShadow("("..selected_page.title..")", 0, 74, 2, "center", 640)
+    Draw.setColor(1, 1, 1)
 
     local menu_x = 185 - 14
     local menu_y = 110
 
     local width = 460
     local height = 32 * 10
-    local total_height = 32 * (#Input.order + 4) -- should be the amount of options there are
+    local total_height = 32 * ( #(selected_page.entries) + ( self.control_menu == "gamepad" and 4 or 3 ) )
 
     Draw.pushScissor()
     Draw.scissor(menu_x, menu_y, width + 10, height + 10)
@@ -298,22 +372,11 @@ function MainMenuControls:draw()
 
     local y_offset = 0
 
-    for index, name in ipairs(Input.order) do
-        Draw.printShadow((Input.getBindName(name) or name:gsub("_", " ")):upper(),  menu_x, menu_y + (32 * y_offset))
+    for _, key in ipairs(selected_page.entries) do
+        Draw.printShadow(key.name, menu_x, menu_y + (32 * y_offset))
 
-        self:drawKeyBindMenu(name, menu_x, menu_y, y_offset)
+        self:drawKeyBindMenu(key.keybind, menu_x, menu_y, y_offset)
         y_offset = y_offset + 1
-    end
-
-    local bind_list = self.control_menu == "gamepad" and Input.gamepad_bindings or Input.key_bindings
-    for name, value in pairs(bind_list) do
-        if not Utils.containsValue(Input.order, name) then
-            Draw.printShadow((Input.getBindName(name) or name:gsub("_", " ")):upper(),  menu_x, menu_y + (32 * y_offset))
-
-            self:drawKeyBindMenu(name, menu_x, menu_y, y_offset)
-            --Draw.printShadow(Utils.titleCase(value[1]),    menu_x + (8 * 32), menu_y + (32 * y_offset))
-            y_offset = y_offset + 1
-        end
     end
 
     y_offset = y_offset + 1
@@ -326,16 +389,38 @@ function MainMenuControls:draw()
     Draw.printShadow("Reset to defaults", menu_x, menu_y + (32 * y_offset))
     Draw.printShadow("Back", menu_x, menu_y + (32 * (y_offset + 1)))
 
-    -- Draw the scrollbar background (lighter than the others since it's against black)
-    Draw.setColor({1, 1, 1, 0.5})
-    love.graphics.rectangle("fill", menu_x + width, 0, 4, menu_y + height - self.scroll_y)
+    if height < total_height then
+        -- Draw the scrollbar background (lighter than the others since it's against black)
+        Draw.setColor({1, 1, 1, 0.5})
+        love.graphics.rectangle("fill", menu_x + width, 0, 4, menu_y + height - self.scroll_y)
 
-    local scrollbar_height = (height / total_height) * height
-    local scrollbar_y = (-self.scroll_y / (total_height - height)) * (height - scrollbar_height)
+        local scrollbar_height = (height / total_height) * height
+        local scrollbar_y = (-self.scroll_y / (total_height - height)) * (height - scrollbar_height)
 
-    Draw.popScissor()
-    Draw.setColor(1, 1, 1, 1)
-    love.graphics.rectangle("fill", menu_x + width, menu_y + scrollbar_y - self.scroll_y, 4, scrollbar_height)
+        Draw.popScissor()
+        Draw.setColor(1, 1, 1, 1)
+        love.graphics.rectangle("fill", menu_x + width, menu_y + scrollbar_y - self.scroll_y, 4, scrollbar_height)
+    else
+        Draw.popScissor()
+    end
+
+    -- Draw menu arrows
+    if #self.pages > 1 then
+        local l_offset, r_offset = 0, 0
+        local mod_width = font:getWidth("("..selected_page.title..")")
+
+        if self.scroll_timer > 0 then
+            if self.scroll_direction == "left" then
+                l_offset = -4
+            elseif self.scroll_direction == "right" then
+                r_offset = 4
+            end
+        end
+
+        Draw.setColor(COLORS.silver)
+        Draw.draw(Assets.getTexture("kristal/menu_arrow_right"), 320 + (mod_width / 2) + 8 + r_offset, 78, 0, 2, 2)
+        Draw.draw(Assets.getTexture("kristal/menu_arrow_left"), 320 - (mod_width / 2) - 26 + l_offset, 78, 0, 2, 2)
+    end
 
     Draw.setColor(COLORS.silver)
     Draw.printShadow("CTRL+ALT+SHIFT+T to reset binds.", 0, 480 - 32, 2, "center", 640)
@@ -419,11 +504,26 @@ function MainMenuControls:getBoundKeys(key)
             table.insert(keys, k)
         end
     end
-    if (self.rebinding or self.selecting_key) and (key == Input.orderedNumberToKey(self.selected_option)) then
+    if (self.rebinding or self.selecting_key) and (key == self:getSelectedKey()) then
         table.insert(keys, "---")
         return keys
     end
     return keys
+end
+
+---@return {title: string, mod:string, entries: {keybind: string, name:string}[]}
+function MainMenuControls:getSelectedPage()
+    return self.pages[self.selected_page]
+end
+
+---@return string? keybind
+function MainMenuControls:getSelectedKey()
+    local page = self:getSelectedPage()
+    local option = self.selected_option
+    if option > #page.entries then
+        return nil
+    end
+    return page.entries[option].keybind
 end
 
 return MainMenuControls

--- a/src/engine/menu/mainmenumodlist.lua
+++ b/src/engine/menu/mainmenumodlist.lua
@@ -129,6 +129,13 @@ function MainMenuModList:onKeyPressed(key, is_repeat)
             end
 
             return true
+        elseif Input.is("mod_rebind", key) then
+            if mod then
+                if Input.mod_keybinds[mod.id] then
+                    self.menu:pushState("CONTROLS", "keyboard", mod.id) -- TODO: gamepad detection
+                    self.list.visible = false -- Hide modlist for now
+                end
+            end
         end
 
         if Input.is("up", key) then self.list:selectUp(is_repeat) end
@@ -173,7 +180,7 @@ end
 function MainMenuModList:draw()
     if self.loading_mods then
         Draw.printShadow("Loading mods...", 0, 115 - 8, 2, "center", 640)
-    else
+    elseif self.menu.state ~= "CONTROLS" then
         local menu_font = Assets.getFont("main")
 
         if #self.list.mods == 0 then
@@ -216,12 +223,15 @@ function MainMenuModList:draw()
 
             local control_menu_width = 0
             local control_cancel_width = 0
+            local control_rebind_width = 0
             if Input.usingGamepad() then
                 control_menu_width = 32
                 control_cancel_width = 32
+                control_rebind_width = 32
             else
                 control_menu_width = menu_font:getWidth(Input.getText("menu"))
                 control_cancel_width = menu_font:getWidth(Input.getText("cancel"))
+                control_rebind_width = menu_font:getWidth(Input.getText("mod_rebind"))
             end
 
             local button = self:getSelectedButton()
@@ -249,6 +259,20 @@ function MainMenuModList:draw()
                 Draw.draw(Input.getTexture("menu"), 580 + (16 * 3) - x_pos, 454 - 8 + 2, 0, 2, 2)
             else
                 Draw.printShadow(Input.getText("menu"), 580 + (16 * 3) - x_pos, 454 - 8)
+            end
+            local mod = self:getSelectedMod()
+            if mod and Input.mod_keybinds[mod.id] then
+                x_pos = x_pos + menu_font:getWidth(" Controls  ")
+                Draw.printShadow(" Controls  ", 580 + (16 * 3) - x_pos, 454 - 8)
+                x_pos = x_pos + control_rebind_width
+                if Input.usingGamepad() then
+                    Draw.setColor(0, 0, 0, 1)
+                    Draw.draw(Input.getTexture("mod_rebind"), 580 + (16 * 3) - x_pos + 2, 454 - 8 + 4, 0, 2, 2)
+                    Draw.setColor(1, 1, 1, 1)
+                    Draw.draw(Input.getTexture("mod_rebind"), 580 + (16 * 3) - x_pos, 454 - 8 + 2, 0, 2, 2)
+                else
+                    Draw.printShadow(Input.getText("mod_rebind"), 580 + (16 * 3) - x_pos, 454 - 8)
+                end
             end
             --local control_text = Input.getText("menu").." "..(self.heart_outline.visible and "Unfavorite" or "Favorite  ").."  "..Input.getText("cancel").." Back"
             --Draw.printShadow(control_text, 580 + (16 * 3) - self.menu_font:getWidth(control_text), 454 - 8, {1, 1, 1, 1})

--- a/src/engine/menu/mainmenumodlist.lua
+++ b/src/engine/menu/mainmenumodlist.lua
@@ -131,9 +131,9 @@ function MainMenuModList:onKeyPressed(key, is_repeat)
             return true
         elseif Input.is("mod_rebind", key) then
             if mod then
-                if Input.mod_keybinds[mod.id] then
-                    self.menu:pushState("CONTROLS", "keyboard", mod.id) -- TODO: gamepad detection
-                    self.list.visible = false -- Hide modlist for now
+                if Input.mod_keybinds[mod.id] and not mod["hideKeybinds"] then
+                    self.menu:pushState("CONTROLS", Input.usingGamepad() and "gamepad" or "keyboard", mod.id) -- TODO: gamepad detection
+                    self.list.visible = false
                 end
             end
         end
@@ -261,7 +261,7 @@ function MainMenuModList:draw()
                 Draw.printShadow(Input.getText("menu"), 580 + (16 * 3) - x_pos, 454 - 8)
             end
             local mod = self:getSelectedMod()
-            if mod and Input.mod_keybinds[mod.id] then
+            if mod and Input.mod_keybinds[mod.id] and not mod["hideKeybinds"] then
                 x_pos = x_pos + menu_font:getWidth(" Controls  ")
                 Draw.printShadow(" Controls  ", 580 + (16 * 3) - x_pos, 454 - 8)
                 x_pos = x_pos + control_rebind_width


### PR DESCRIPTION
Aside from what is mentioned in the title, there are a few additional miscellaneous tweaks in this pull:
- `hideKeybinds` mod config to optionally hide all your mod's keybinds from the Main Menu (for mod authors who want to make thier own in-mod rebind system)
- New keybind `mod_rebind` - Used to open the Mod Controls menu (see below)
- Mod Controls menu - for mods that define keybinds, the `mod_rebind` key (default `/` on keyboard) can be pressed on the ModList screen to open up their specific keybind page (Will auto-switch between gamepad/keyboard if you change inputs!)
- `Input.mod_keybinds` table - okay this isn't a real feature but if for some reason you needed to know what keybinds a mod uses this table has a list of them (only includes the *keybind name* and *not* the bound keys)
- `Input.resetBinds(gamepad, mod_id)` - similar to above this is mainly for the controls menu but if you wanted to reset a specific mod's keybinds you can now do it with `resetBinds` here - or use "KRISTAL" as the `mod_id` to reset all of the kristal keybinds

An extra important clarification too: this does NOT change anything about how keybinds are stored, they continue to be shared between mods that define the same bind and will appear in all of those mods keybinds with the same bound key and update accordingly as it is changed