### PR TITLE
Documentation for `Stage`, `Sprite`, `ActorSprite`

### DIFF
--- a/src/engine/game/battle/battlecutscene.lua
+++ b/src/engine/game/battle/battlecutscene.lua
@@ -2,11 +2,14 @@
 --- These cutscene scripts will receive a BattleCutscene as their first argument.
 ---
 ---@class BattleCutscene : Cutscene
----@overload fun(...) : BattleCutscene
+---@overload fun(group: string, id?: string, ...) : BattleCutscene
 local BattleCutscene, super = Class(Cutscene)
 
 local function _true() return true end
 
+---@param group fun(cutscene: Cutscene, ...)
+---@param id? string
+---@param ... unknown
 function BattleCutscene:init(group, id, ...)
     local scene, args = self:parseFromGetter(Registry.getBattleCutscene, group, id, ...)
 

--- a/src/engine/game/common/actorsprite.lua
+++ b/src/engine/game/common/actorsprite.lua
@@ -177,6 +177,16 @@ function ActorSprite:_setSprite(texture, keep_anim)
     end
 end
 
+--- Sets the animation of the current sprite. \
+--- The animation specified in `anim` can be one of the following:
+--- - `string` - The name of an animation defined on the sprite's current actor.
+--- - `table` - a table of animation data. Refer to [`Sprite:setAnimation(anim)`](lua://Sprite.setAnimation) for how to use this, as well as the additional keys supported on `ActorSprite` listed below:
+--- - - `temp: boolean` - Whether the previous aniamtion/sprite should be set once the new animation is stops (Defaults to `false`)
+--- - `function` - An animation routine
+---@param anim? table|string|function?
+---@param callback? fun(sprite: ActorSprite)    A callback to run when the animation finishes
+---@param ignore_actor_callback? boolean        Whether to skip calling [`Actor:preSetAnimation()`](lua://Actor.preSetAnimation)
+---@return boolean
 function ActorSprite:setAnimation(anim, callback, ignore_actor_callback)
     if not ignore_actor_callback and self.actor:preSetAnimation(self, anim, callback) then
         return

--- a/src/engine/game/common/actorsprite.lua
+++ b/src/engine/game/common/actorsprite.lua
@@ -1,7 +1,43 @@
 --- An extension of `Sprite` that can integrate with an actor.
 --- If an object defines an Actor, it will use this over `Sprite` for its sprite.
+--- 
 ---@class ActorSprite : Sprite
----@overload fun(...) : ActorSprite
+---
+---@field actor             Actor                               *(Read-only)* The actor associated with this sprite
+---@field sprite            string?                             *(Read-only)* The current texture of the sprite, if it exists
+---@field full_sprite       string?                             *(Read-only)* The full string path of the current texture, if it exists
+---@field anim              table|string|function?              *(Read-only)* The current animation set on the sprite
+---@field facing            "up"|"down"|"left"|"right"          *(Read-only)* The sprite's current facing direction
+---@field last_facing       "up"|"down"|"left"|"right"          *(Read-only)* The direction the sprite was facing on the previous frame
+---@field sprite_options    table                               *(Read-only)*
+---
+---@field temp_anim         table|string|function?              *(Read-only)* The animation that will be set when the current temporary animation stops
+---@field temp_sprite       string?                             *(Read-only)* The sprite that will be set when the current temporary animation stops 
+---
+---@field directional       boolean?                            *(Read-only)* Whether the current sprite changes based on the facing direction
+---@field dir_sep           string?                             *(Read-only)* The separator the current sprite uses for its directional sprites. Either `"_"` or `"/"`
+---
+---@field offsets           table<string, [number, number]>     *(Read-only)* A table of offset positions for sprites (inherited from [`Actor.offsets`](lua://Actor.offsets))
+---
+---@field walking           boolean                             Whether the sprite is currently walking
+---@field walk_speed        number                              The movement speed of the character attached to this sprite
+---@field walk_frame        number                              *(Read-only)* The current frame of the walking animation
+---@field walk_override     boolean                             *(Read-only)* Enables special update code for the walk animation
+---
+---@field aura              boolean                             Whether the sprite currently has a glowing aura (used for `ChaserEnemy` objects)
+---@field aura_siner        number                              A timer used for the aura effect
+---
+---@field run_away          boolean                             Special draw mode for enemies running away from battle on defeat
+---@field run_away_timer    number                              A timer used for the run away animation
+---
+---@field frozen            boolean                             Whether the sprite has a frozen overlay
+---@field freeze_progress   number                              The percentage of the enemy that is frozen, as a number ranging from 0 to 1
+---
+---@field on_footstep       fun(sprite: Sprite, cycle: number)? A callback function that is run whenever the character is in the "step" part of their animation while walking
+---
+---@field last_flippable    boolean                             
+---
+---@overload fun(actor: string|Actor) : ActorSprite
 local ActorSprite, super = Class(Sprite)
 
 function ActorSprite:init(actor)
@@ -68,12 +104,17 @@ function ActorSprite:resetSprite(ignore_actor_callback)
     self.actor:onResetSprite(self)
 end
 
+--- *(Called internally)* Sets the current sprite to a single texture. \
+--- **Note**: *Only for internal overrides. Use `Sprite:setSprite()` instead.*
 function ActorSprite:setTextureExact(texture)
     super.setTextureExact(self, texture)
 
     self.sprite_options = self.actor:parseSpriteOptions(self.texture_path)
 end
 
+--- Sets or replaces the current actor on the sprite. \
+--- *Will also reset the sprite through [`ActorSprite:setSprite()`](lua://ActorSprite.setSprite)*
+---@param actor string|Actor
 function ActorSprite:setActor(actor)
     if type(actor) == "string" then
         actor = Registry.createActor(actor)
@@ -110,6 +151,12 @@ function ActorSprite:setCustomSprite(texture, ox, oy, keep_anim)
     self:_setSprite(texture, keep_anim)
 end
 
+--- Sets the sprite to either a texture or an animation \
+--- If the current actor has an animation with a name matching `name`, it will be passed into [`ActorSprite:setAnimation()`](lua://ActorSprite.setAnimation). \
+--- Otherwise, it will be passed into [`ActorSprite:setSprite()`](lua://ActorSprite.setSprite).
+---@param name                      string|nil
+---@param callback?                 fun(sprite: ActorSprite)
+---@param ignore_actor_callback?    boolean
 function ActorSprite:set(name, callback, ignore_actor_callback)
     if not ignore_actor_callback and self.actor:preSet(self, name, callback) then
         return
@@ -125,6 +172,7 @@ function ActorSprite:set(name, callback, ignore_actor_callback)
     self.actor:onSet(self, name, callback)
 end
 
+--- Sets the current sprite
 ---@param texture?                  string
 ---@param keep_anim?                boolean
 ---@param ignore_actor_callback?    boolean
@@ -140,6 +188,7 @@ function ActorSprite:setSprite(texture, keep_anim, ignore_actor_callback)
     self.actor:onSetSprite(self, texture, keep_anim)
 end
 
+--- *(Called internally)* Sets the current sprite
 ---@param texture?      string
 ---@param keep_anim?    boolean
 function ActorSprite:_setSprite(texture, keep_anim)
@@ -186,7 +235,7 @@ end
 ---@param anim? table|string|function?
 ---@param callback? fun(sprite: ActorSprite)    A callback to run when the animation finishes
 ---@param ignore_actor_callback? boolean        Whether to skip calling [`Actor:preSetAnimation()`](lua://Actor.preSetAnimation)
----@return boolean
+---@return boolean?
 function ActorSprite:setAnimation(anim, callback, ignore_actor_callback)
     if not ignore_actor_callback and self.actor:preSetAnimation(self, anim, callback) then
         return
@@ -238,11 +287,16 @@ function ActorSprite:setAnimation(anim, callback, ignore_actor_callback)
     end
 end
 
+--- Sets the current sprite and starts animating it based on [`walk_speed`](lua://ActorSprite.walk_speed) and [`walking`](lua://ActorSprite.walking)
+---@param texture string
 function ActorSprite:setWalkSprite(texture)
     self:setSprite(texture)
     self.walk_override = true
 end
 
+--- Whether this sprite can talk using it's current sprite
+---@return boolean can_talk     Whether a talksprite is defined
+---@return number talk_speed    The speed at which the talk sprite should animate, in seconds
 function ActorSprite:canTalk()
     for _,sprite in ipairs(self.sprite_options) do
         if self.actor:hasTalkSprite(sprite) then
@@ -252,11 +306,14 @@ function ActorSprite:canTalk()
     return false, 0.25
 end
 
+--- Sets the facing direction of the current sprite
+---@param facing "up"|"down"|"left"|"right"
 function ActorSprite:setFacing(facing)
     self.facing = facing
     self:updateDirection()
 end
 
+--- *(Called internally)* Updates the current sprite to match the current facing direction
 function ActorSprite:updateDirection()
     if self.directional and self.last_facing ~= self.facing then
         super.setSprite(self, self:getDirectionalPath(self.sprite), true)
@@ -264,10 +321,16 @@ function ActorSprite:updateDirection()
     self.last_facing = self.facing
 end
 
+--- Checks whether `sprite` matches the sprite's current texture
+---@param sprite string
+---@return boolean
 function ActorSprite:isSprite(sprite)
     return Utils.containsValue(self.sprite_options, sprite)
 end
 
+--- Selects from the given table `tbl` the relevant value for the current sprite, if it exists
+---@param tbl table
+---@return any
 function ActorSprite:getValueForSprite(tbl)
     for _,sprite in ipairs(self.sprite_options) do
         if tbl[sprite] then
@@ -276,6 +339,11 @@ function ActorSprite:getValueForSprite(tbl)
     end
 end
 
+--- *(Called internally)* Checks whether a particular `texture` has sprites defined for multiple facing directions \
+--- **Note:** Assumes that all four directions are always defined
+---@param texture string
+---@return boolean? directional
+---@return string? separator
 function ActorSprite:isDirectional(texture)
     if not Assets.getTexture(texture) and not Assets.getFrames(texture) then
         if Assets.getTexture(texture.."_left") or Assets.getFrames(texture.."_left") then
@@ -286,6 +354,9 @@ function ActorSprite:isDirectional(texture)
     end
 end
 
+--- *(Called internally)* Gets the path for a directional sprite based on the current facing direction
+---@param sprite string
+---@return string new_sprite
 function ActorSprite:getDirectionalPath(sprite)
     if sprite ~= "" then
         return sprite..self.dir_sep..self.facing
@@ -294,6 +365,7 @@ function ActorSprite:getDirectionalPath(sprite)
     end
 end
 
+---@return [number, number]
 function ActorSprite:getOffset()
     local offset = {0, 0}
     if self.force_offset then
@@ -371,6 +443,7 @@ function ActorSprite:update()
     self.actor:onSpriteUpdate(self)
 end
 
+---@param transform love.Transform
 function ActorSprite:applyTransformTo(transform)
     super.applyTransformTo(self, transform)
     local offset = self:getOffset()

--- a/src/engine/game/common/cutscene.lua
+++ b/src/engine/game/common/cutscene.lua
@@ -4,9 +4,11 @@
 ---@see LegendCutscene  # For functions specific to legend cutscene scripts.
 ---
 ---@class Cutscene : Class
----@overload fun(...) : Cutscene
+---@overload fun(func: fun(cutscene: Cutscene, ...), ...) : Cutscene
 local Cutscene, super = Class()
 
+---@param func fun(cutscene: Cutscene, ...)
+---@param ... unknown
 function Cutscene:init(func, ...)
     self.wait_timer = 0
     self.wait_func = nil
@@ -24,6 +26,12 @@ function Cutscene:init(func, ...)
     self:resume(self, ...)
 end
 
+---@param getter fun(...) : fun(...)|nil
+---@param cutscene fun(...)|string
+---@param id? string
+---@param ... unknown
+---@return fun(...) cutscene
+---@return table args
 function Cutscene:parseFromGetter(getter, cutscene, id, ...)
     self.getter = getter
     if type(cutscene) == "function" then

--- a/src/engine/game/world/character.lua
+++ b/src/engine/game/world/character.lua
@@ -1,7 +1,7 @@
 --- All types of character in the overworld inherit from the `Character` class. \
 --- This class is not to be confused with the psuedo-event [`NPC`](lua://NPC.init) that is used for characters placed in the overworld.
 ---@class Character : Object
----@overload fun(...) : Character
+---@overload fun(actor: string|Actor, x?: number, y?: number) : Character
 local Character, super = Class(Object)
 
 function Character:init(actor, x, y)

--- a/src/engine/game/world/chaserenemy.lua
+++ b/src/engine/game/world/chaserenemy.lua
@@ -53,7 +53,7 @@
 ---@field visible           boolean
 ---@field reverse_progress  boolean
 ---
----@overload fun(...) : ChaserEnemy
+---@overload fun(actor: string|Actor, x?: number, y?: number, properties?: table) : ChaserEnemy
 local ChaserEnemy, super = Class(Character, "enemy")
 
 function ChaserEnemy:init(actor, x, y, properties)

--- a/src/engine/game/world/follower.lua
+++ b/src/engine/game/world/follower.lua
@@ -1,6 +1,6 @@
 --- Followers are a type of Overworld character that follow the player's movements.
 ---@class Follower : Character
----@overload fun(...) : Follower
+---@overload fun(chara: string|Actor, x?: number, y?: number, target: Player) : Follower
 local Follower, super = Class(Character)
 
 function Follower:init(chara, x, y, target)

--- a/src/engine/game/world/frozenenemy.lua
+++ b/src/engine/game/world/frozenenemy.lua
@@ -2,7 +2,7 @@
 --- Enemies that are frozen in battle will automatically turn into statues when returning to the Overworld.
 ---@class FrozenEnemy : Interactable
 ---
----@field text string Text displayed when interacting with the statue
+---@field text string[] Text displayed when interacting with the statue
 ---
 ---@field sprite ActorSprite
 ---@field actor Actor
@@ -10,9 +10,13 @@
 ---@field solid boolean
 ---@field encounter string 
 ---
----@overload fun(...) : FrozenEnemy
+---@overload fun(actor: string|Actor, x: number, y: number, properties: table) : FrozenEnemy
 local FrozenEnemy, super = Class(Interactable)
 
+---@param actor         string|Actor
+---@param x?            number
+---@param y?            number
+---@param properties?   table
 function FrozenEnemy:init(actor, x, y, properties)
     if type(actor) == "string" then
         actor = Registry.createActor(actor)

--- a/src/engine/game/world/overworldsoul.lua
+++ b/src/engine/game/world/overworldsoul.lua
@@ -4,7 +4,7 @@
 ---
 ---@field collider CircleCollider The hitbox of the soul, defaulting to a circle with an 8 pixel radius
 ---
----@overload fun(...) : OverworldSoul
+---@overload fun(x?: number, y?: number) : OverworldSoul
 local OverworldSoul, super = Class(Object)
 
 function OverworldSoul:init(x, y)

--- a/src/engine/game/world/player.lua
+++ b/src/engine/game/world/player.lua
@@ -1,6 +1,6 @@
 --- The character controlled by the player when in the Overworld.
 ---@class Player : Character
----@overload fun(...) : Player
+---@overload fun(chara: string|Actor, x?: number, y?: number) : Player
 local Player, super = Class(Character)
 
 function Player:init(chara, x, y)

--- a/src/engine/game/world/worldbullet.lua
+++ b/src/engine/game/world/worldbullet.lua
@@ -4,7 +4,6 @@
 --- Extension bullets can be spawned into the world with `Game.world:spawnBullet(id, ...)` - their `id` defaults to their filepath, starting from `scripts/world/bullets`. Additional arguments `...` are passed into the bullet type's init function.
 ---
 ---@class WorldBullet : Object
----@overload fun(...) : WorldBullet
 ---
 ---@field world             World           The current World instance. Not defined until after `WorldBullet:init()`, and only if it is parented to a World instance.
 ---
@@ -18,6 +17,7 @@
 ---
 ---@field remove_offscreen  boolean
 ---
+---@overload fun(x?: number, y?: number, texture?: string|love.Image) : WorldBullet
 local WorldBullet, super = Class(Object)
 
 ---@param x         number

--- a/src/engine/game/world/worldcutscene.lua
+++ b/src/engine/game/world/worldcutscene.lua
@@ -16,11 +16,15 @@
 ---
 ---@field world World   Reference to Game.world
 ---
----@overload fun(...) : WorldCutscene
+---@overload fun(world: World, group: string, id?: string, ...) : WorldCutscene
 local WorldCutscene, super = Class(Cutscene)
 
 local function _true() return true end
 
+---@param world World
+---@param group string
+---@param id? string
+---@param ... unknown
 function WorldCutscene:init(world, group, id, ...)
     local scene, args = self:parseFromGetter(Registry.getWorldCutscene, group, id, ...)
 

--- a/src/engine/objects/sprite.lua
+++ b/src/engine/objects/sprite.lua
@@ -133,8 +133,8 @@ function Sprite:isSprite(texture)
 end
 
 --- Sets the sprite to either a texture or an animation. \
---- If the given texture is a string or image, it will be passed into `Sprite:setSprite()`. \
---- If the given texture is a table, it will be passed into `Sprite:setAnimation()`.
+--- If the given texture is a string or image, it will be passed into [`Sprite:setSprite()`](lua://Sprite.setSprite). \
+--- If the given texture is a table, it will be passed into [`Sprite:setAnimation()`](lua://Sprite.setAnimation).
 ---@param texture string|table|love.Image  The texture or animation to set the sprite to.
 function Sprite:set(texture)
     if type(texture) == "table" then

--- a/src/engine/objects/sprite.lua
+++ b/src/engine/objects/sprite.lua
@@ -222,8 +222,31 @@ end
 ---@alias Sprite.anim_func     fun(wait:Sprite.wait_func)
 ---@alias Sprite.anim_callback fun(sprite:Sprite)
 
--- TODO: Document the rest of Sprite
+-- Fix this awful parameter doc (can anims maybe use a custom type? options style docs could also work)
 
+--- Sets the animation of the current sprite. \
+--- The animation specified in `anim` can take on multiple forms:
+--- - `fun(wait: fun(time: number))`    - The animation routine. Receives the animation coroutine's wait function. 
+---                                         See [`Sprite:_basicAnimation(wait)`](lua://Sprite._basicAnimation) for an example of an animation routine
+--- - `table`                           - A table of animation data, in one of these three formats:
+--- - - `string|table`                  - The name of the sprite, or a table of frames of the animation, \
+---     `number`                        - The time, in seconds, between each frame, \
+---     `boolean`                       - Whether the animation should loop
+--- - - `string|table`                  - The name of the sprite, or a table of frames of the animation, \
+---     `fun(wait: fun(time: number))`  - An animation routine
+--- - - `fun(wait: fun(time: number))`  - An animation routine
+--- 
+--- Additionally, these keys can be defined in the `anim` table for further customisation:
+--- - `duration: number`                - The time, in seconds, that the animation will run for
+--- - `callback: fun(self: Sprite)`     - A callback that will run when the sprite stops animating. Receives the sprite as an argument
+--- - `frames: (number|string)[]`       - A custom sequence of frame numbers to use for the aniamtion: \
+---                                         Can use special notation: `num` (frame numbers), `"num1-num2"` (sequential frames from `num1` to `num2`), and `"num1*num2"` (repeat frame `num1` `num2` times). \
+---                                         Only takes effect when not using a custom animation routine
+--- - `next: string|table`              - Another animation to play when the current one finishes. If this is a table, a random entry will be selected as the next animation
+---@overload fun(self: Sprite, anim: {[1]: string|table, [2]: number, [3]: boolean, callback: fun(self: Sprite), duration: number, frames: (number|string)[], next: string|table})
+---@overload fun(self: Sprite, anim: {[1]: string|table, [2]: function, callback: fun(self: Sprite), duration: number, frames: (number|string)[], next: string|table})
+---@overload fun(self: Sprite, anim: {[1]: function, callback: fun(self: Sprite), duration: number, frames: (number|string)[], next: string|table})
+---@overload fun(self: Sprite, anim: fun(wait: fun(time: number)))
 function Sprite:setAnimation(anim)
     self:stop(true)
     self.anim_duration = -1
@@ -278,6 +301,9 @@ function Sprite:setAnimation(anim)
     coroutine.resume(self.anim_routine, self, self.anim_wait_func)
 end
 
+--- *(Called internally)* Parses animation frame data into a table of frame numbers
+---@param frames? (number|string)[] Input animation: Can use `num` (frame numbers), (`"num1-num2"` sequential frames from `num1` to `num2`), and `"num1*num2"` (repeat frame `num1` `num2` times)
+---@return number[]? anim Output animation: Uses only frame numbers
 function Sprite:parseFrames(frames)
     if not frames then return end
     local t = {}
@@ -309,6 +335,8 @@ function Sprite:parseFrames(frames)
     return t
 end
 
+--- *(Called internally)* Default animation routine
+---@param wait fun(time: number) The animation coroutine's `wait` function
 function Sprite:_basicAnimation(wait)
     while true do
         if type(self.anim_frames) == "table" then
@@ -329,6 +357,10 @@ function Sprite:_basicAnimation(wait)
     end
 end
 
+--- Starts animating the sprite's current texture
+---@param speed?         number                 The speed of the animation as the number of seconds between frames (Defaults to `1/30`)
+---@param loop?          boolean                Whether the animation should loop (Defautls to `false`)
+---@param on_finished?   fun(sprite: Sprite)    A function to run when the animation finishes
 function Sprite:play(speed, loop, on_finished)
     if loop == nil then
         loop = true
@@ -340,6 +372,8 @@ function Sprite:resume()
     self.playing = true
 end
 
+--- Stops the animation of the current sprite
+---@param keep_frame boolean? Whether to keep the current frame of the sprite. If false, the sprite sets back to the first frame
 function Sprite:stop(keep_frame)
     self.playing = false
     self.loop = false
@@ -359,6 +393,10 @@ function Sprite:pause()
     self.playing = false
 end
 
+---@param offset_x? number  The x-offset of the flash sprite
+---@param offset_y? number  The y-offset of the flash sprite
+---@param layer?    number  (Defaults to `100`)
+---@return FlashFade
 function Sprite:flash(offset_x, offset_y, layer)
     local flash = FlashFade(self.texture, offset_x or 0, offset_y or 0)
     flash.layer = layer or 100 -- TODO: Unhardcode?
@@ -366,6 +404,8 @@ function Sprite:flash(offset_x, offset_y, layer)
     return flash
 end
 
+--- *(Called internally)* Sets the target texture for the current cross-fade
+---@param texture string|love.Image
 function Sprite:setCrossFadeTexture(texture)
     if type(texture) == "string" then
         texture = self:getPath(texture)
@@ -376,6 +416,7 @@ function Sprite:setCrossFadeTexture(texture)
     self.crossfade_texture_path = Assets.getTextureID(texture)
 end
 
+--- Stops the cross-fade on the current sprite
 function Sprite:resetCrossFade()
     self.crossfade_alpha = 0
     self.crossfade_texture = nil
@@ -385,10 +426,20 @@ function Sprite:resetCrossFade()
     self.crossfade_after = nil
 end
 
+--- Starts a cross-fade from the current sprite to a new `texture`
+---@param texture   string|love.Image   The texture to fade into
+---@param time?     number              The time, in seconds, that the cross-fade should take (Defaults to `1`)
+---@param fade_out? boolean             Whether the current sprite texture should fade out during the cross-fade (if `false`, it disappears at the end)
+---@param after?    fun(sprite: Sprite) The function to run when the cross-fade is complete
 function Sprite:crossFadeTo(texture, time, fade_out, after)
     self:crossFadeToSpeed(texture, (1 / (time or 1)) / 30 * (1 - self.crossfade_alpha), fade_out, after)
 end
 
+--- Starts a cross-fade from the current sprite to a new `texture`
+---@param texture   string|love.Image   The texture to fade into
+---@param speed?    number              The speed at which the alpha of both sprites change, meaasured as the alpha value change per frame at 30FPS (Defaults to `0.04`)
+---@param fade_out? boolean             Whether the current sprite texture should fade out during the cross-fade (if `false`, it disappears at the end)
+---@param after?    fun(sprite: Sprite) The function to run when the cross-fade is complete
 function Sprite:crossFadeToSpeed(texture, speed, fade_out, after)
     self:setCrossFadeTexture(texture)
     self.crossfade_speed = speed or 0.04

--- a/src/engine/objects/stage.lua
+++ b/src/engine/objects/stage.lua
@@ -1,5 +1,18 @@
+--- The Stage object in Kristal is designed to be the highest parent object at all times. \
+--- All throughout gameplay, the active stage is [`Game.stage`](lua://Game.stage), while when in the Kristal menu, [`Kristal.Stage`](lua://Kristal.Stage) is the stage instead.
+---
 ---@class Stage : Object
----@overload fun(...) : Stage
+---@
+---@field objects           Object[]                A list of all the objects attached to this stage
+---@field objects_by_class  table<Class, Object[]>  A list of all the objects attached to this stage, sorted by the classes that they include
+---@field objects_to_remove Object[]                A list of objects pending removal from this stage (removed on the next update tick)
+---@
+---@field stage Stage
+---@
+---@field full_updating boolean
+---@field full_drawing boolean
+---@
+---@overload fun(x: number, y: number, w: number, h: number) : Stage
 local Stage, super = Class(Object)
 
 function Stage:init(x, y, w, h)
@@ -18,6 +31,9 @@ function Stage:init(x, y, w, h)
     self:addChild(self.timer)
 end
 
+--- Gets every object attached to this stage that inherits from `class`
+---@param class Class       The included Class to select from
+---@return Object[] matches All the objects parented to this stage that inherit from `class`
 function Stage:getObjects(class)
     if class then
         return Utils.filter(self.objects_by_class[class] or {}, function(o) return o.stage == self end)
@@ -26,6 +42,8 @@ function Stage:getObjects(class)
     end
 end
 
+--- Adds an object and all of its children to this stage
+---@param object Object
 function Stage:addToStage(object)
     table.insert(self.objects, object)
     for class,_ in pairs(object.__includes_all) do
@@ -50,6 +68,8 @@ function Stage:updateAllLayers()
     end
 end
 
+--- Removes an object and all of its children from this stage
+---@param object Object
 function Stage:removeFromStage(object)
     table.insert(self.objects_to_remove, object)
     if object.stage == self then

--- a/src/engine/objects/stage.lua
+++ b/src/engine/objects/stage.lua
@@ -12,7 +12,7 @@
 ---@field full_updating boolean
 ---@field full_drawing boolean
 ---@
----@overload fun(x: number, y: number, w: number, h: number) : Stage
+---@overload fun(x?: number, y?: number, w?: number, h?: number) : Stage
 local Stage, super = Class(Object)
 
 function Stage:init(x, y, w, h)

--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -1,3 +1,4 @@
+---@class Kristal
 local Kristal = {}
 
 if not HOTSWAPPING then

--- a/src/utils/utils.lua
+++ b/src/utils/utils.lua
@@ -1,3 +1,4 @@
+---@class Utils
 local Utils = {}
 
 ---


### PR DESCRIPTION
aside from the stuff above, i've also marked the `Kristal` and `Utils` tables as classes so that the API reference and symbol references will recognise them, and changed some overloads from being just `fun(...)` to their actual constructor arguments