### PR TITLE
Add support for `string`/`number` types in the flag editor, flag filtering, and `Utils.squishAndTrunc()`

### DIFF
--- a/mods/_testmod/mod.json
+++ b/mods/_testmod/mod.json
@@ -33,6 +33,10 @@
     "quickReload": true,
     "hidden": false,
 
+    "defaultFlagFilterType": "any",
+    "defaultFlagFilterQuery": "#",
+    "defaultFlagFilterMode": "invert_startsWith",
+
     "config": {
         "kristal": {
             //"growStrongerChara": "susie",

--- a/src/engine/game/debugsystem.lua
+++ b/src/engine/game/debugsystem.lua
@@ -1514,9 +1514,48 @@ function DebugSystem:draw()
         self:printShadow("Filter Settings", text_offset + 19, y_off + menu_y + 16 + self.menu_y)
         if Game.flags then
             for index, key in pairs(self.filtered_flags_list) do
-                self:printShadow(key, text_offset + 19, y_off + menu_y + (index) * 32 + 16 + self.menu_y)
-                self:printShadow(tostring(Game.flags[key]), -16, y_off + menu_y + (index) * 32 + 16 + self.menu_y,
-                                 { 1, 1, 1, 1 }, "right", 640)
+                local width = self.font:getWidth(key)
+                local trunc_key
+                local sx = 1
+                if width > (480 - 32) then
+                    sx = (480 - 32) / width
+                    if sx < 0.6 then
+                        sx = 0.6
+                        local dotwidth = self.font:getWidth("...") * 0.6
+                        for i=1, string.len(key) do
+                            trunc_key = string.sub(key, 1, i)
+                            width = self.font:getWidth(trunc_key) * 0.6
+                            if width > (480 - 32 - dotwidth) then
+                                trunc_key = string.sub(key, 1, i-1)
+                                break
+                            end
+                        end
+                        trunc_key = trunc_key .. "..."
+                    end
+                end
+                self:printShadow(trunc_key or key, text_offset + 19, y_off + menu_y + (index) * 32 + 16 + self.menu_y, nil, nil, nil, sx)
+                local value = tostring(Game.flags[key])
+                width = self.font:getWidth(value)
+                sx = 1
+                if width > (160 - 32) then
+                    sx = (160 - 32) / width
+                    if sx < 0.6 then
+                        sx = 0.6
+                        local dotwidth = self.font:getWidth("...") * 0.6
+                        local trunc_val
+                        for i=1, string.len(value) do
+                            trunc_val = string.sub(value, 1, i)
+                            width = self.font:getWidth(trunc_val) * 0.6
+                            if width > (160 - 32 - dotwidth) then
+                                trunc_val = string.sub(value, 1, i-1)
+                                break
+                            end
+                        end
+                        value = trunc_val .. "..."
+                    end
+                end
+                self:printShadow(tostring(value), 480 + 16, y_off + menu_y + (index) * 32 + 16 + self.menu_y,
+                                 { 1, 1, 1, 1 }, "right", nil, sx)
             end
         end
         Draw.popScissor()
@@ -1588,7 +1627,14 @@ function DebugSystem:draw()
             x = x,
             y = y,
             font = self.font,
-            print = function (text, x, y) self:printShadow(text, x, y) end,
+            print = function (text, x, y) 
+                local width = self.font:getWidth(text)
+                local sx = 1
+                if width > 320 then
+                    sx = 320 / width
+                end
+                self:printShadow(text, x, y, nil, nil, nil, sx)
+            end,
         })
 
         self:printShadow(name, 0, 480 - 32 + name_offset, COLORS.gray, "center", 640)
@@ -1751,16 +1797,16 @@ function DebugSystem:draw()
     super.draw(self)
 end
 
-function DebugSystem:printShadow(text, x, y, color, align, limit)
+function DebugSystem:printShadow(text, x, y, color, align, limit, sx, sy)
     color = color or { 1, 1, 1, 1 }
     -- Draw the shadow, offset by two pixels to the bottom right
     love.graphics.setFont(self.font)
     Draw.setColor({ 0, 0, 0, color[4] })
-    love.graphics.printf(text, x + 2, y + 2, limit or self.font:getWidth(text), align or "left")
+    love.graphics.printf(text, x + 2, y + 2, limit or self.font:getWidth(text), align or "left", 0, sx or 1, sy or 1)
 
     -- Draw the main text
     Draw.setColor(color)
-    love.graphics.printf(text, x, y, limit or self.font:getWidth(text), align or "left")
+    love.graphics.printf(text, x, y, limit or self.font:getWidth(text), align or "left", 0, sx or 1, sy or 1)
 end
 
 return DebugSystem

--- a/src/engine/game/debugsystem.lua
+++ b/src/engine/game/debugsystem.lua
@@ -1037,9 +1037,35 @@ function DebugSystem:onKeyPressed(key, is_repeat)
                 return
             elseif Input.isConfirm(key) then
                 local keys = Utils.getKeys(Game.flags)
-                if type(Game:getFlag(keys[self.current_selecting])) == "boolean" then
-                    Game:setFlag(keys[self.current_selecting], not Game:getFlag(keys[self.current_selecting]))
+                local flag_name = keys[self.current_selecting]
+                if type(Game:getFlag(flag_name)) == "boolean" then
+                    Game:setFlag(flag_name, not Game:getFlag(flag_name))
                     Assets.playSound("ui_select")
+                elseif type(Game:getFlag(flag_name)) == "number" then
+                    Assets.playSound("ui_select")
+                    self.window = DebugWindow("Edit Flag (number) - \"".. flag_name .."\"", "Enter a new value for this flag.", "input", function (text)
+                        local num = tonumber(text)
+                        if num then
+                            Game:setFlag(flag_name, num)
+                            Assets.playSound("ui_select")
+                        else
+                            Assets.playSound("ui_cant_select")
+                        end
+                    end)
+                    self.window:setPosition(Input.getCurrentCursorPosition())
+                    self.window.input_lines[1] = Game:getFlag(flag_name)
+                    TextInput.cursor_x = string.len(Game:getFlag(flag_name))
+                    self:addChild(self.window)
+                elseif type(Game:getFlag(flag_name)) == "string" then
+                    Assets.playSound("ui_select")
+                    self.window = DebugWindow("Edit Flag (string) - \"".. flag_name .."\"", "Enter a new value for this flag.", "input", function (text)
+                        Game:setFlag(flag_name, text)
+                        Assets.playSound("ui_select")
+                    end)
+                    self.window:setPosition(Input.getCurrentCursorPosition())
+                    self.window.input_lines[1] = Game:getFlag(flag_name)
+                    TextInput.cursor_x = string.len(Game:getFlag(flag_name))
+                    self:addChild(self.window)
                 else
                     Assets.playSound("ui_cant_select")
                 end

--- a/src/engine/game/debugsystem.lua
+++ b/src/engine/game/debugsystem.lua
@@ -1514,47 +1514,10 @@ function DebugSystem:draw()
         self:printShadow("Filter Settings", text_offset + 19, y_off + menu_y + 16 + self.menu_y)
         if Game.flags then
             for index, key in pairs(self.filtered_flags_list) do
-                local width = self.font:getWidth(key)
-                local trunc_key
-                local sx = 1
-                if width > (480 - 32) then
-                    sx = (480 - 32) / width
-                    if sx < 0.6 then
-                        sx = 0.6
-                        local dotwidth = self.font:getWidth("...") * 0.6
-                        for i=1, string.len(key) do
-                            trunc_key = string.sub(key, 1, i)
-                            width = self.font:getWidth(trunc_key) * 0.6
-                            if width > (480 - 32 - dotwidth) then
-                                trunc_key = string.sub(key, 1, i-1)
-                                break
-                            end
-                        end
-                        trunc_key = trunc_key .. "..."
-                    end
-                end
-                self:printShadow(trunc_key or key, text_offset + 19, y_off + menu_y + (index) * 32 + 16 + self.menu_y, nil, nil, nil, sx)
-                local value = tostring(Game.flags[key])
-                width = self.font:getWidth(value)
-                sx = 1
-                if width > (160 - 32) then
-                    sx = (160 - 32) / width
-                    if sx < 0.6 then
-                        sx = 0.6
-                        local dotwidth = self.font:getWidth("...") * 0.6
-                        local trunc_val
-                        for i=1, string.len(value) do
-                            trunc_val = string.sub(value, 1, i)
-                            width = self.font:getWidth(trunc_val) * 0.6
-                            if width > (160 - 32 - dotwidth) then
-                                trunc_val = string.sub(value, 1, i-1)
-                                break
-                            end
-                        end
-                        value = trunc_val .. "..."
-                    end
-                end
-                self:printShadow(tostring(value), 480 + 16, y_off + menu_y + (index) * 32 + 16 + self.menu_y,
+                local print_key, sx = Utils.squishAndTrunc(key, self.font, 480 - 32, 1, 0.6, "...")
+                self:printShadow(print_key, text_offset + 19, y_off + menu_y + (index) * 32 + 16 + self.menu_y, nil, nil, nil, sx)
+                local print_value, sx = Utils.squishAndTrunc(tostring(Game.flags[key]), self.font, 160 - 32, 1, 0.6, "...")
+                self:printShadow(print_value, 480 + 16, y_off + menu_y + (index) * 32 + 16 + self.menu_y,
                                  { 1, 1, 1, 1 }, "right", nil, sx)
             end
         end
@@ -1627,13 +1590,9 @@ function DebugSystem:draw()
             x = x,
             y = y,
             font = self.font,
-            print = function (text, x, y) 
-                local width = self.font:getWidth(text)
-                local sx = 1
-                if width > 320 then
-                    sx = 320 / width
-                end
-                self:printShadow(text, x, y, nil, nil, nil, sx)
+            print = function (text, x, y)
+                local text, scale = Utils.squishAndTrunc(text, self.font, 320, 1, 0.4, "...")
+                self:printShadow(text, x, y, nil, nil, nil, scale)
             end,
         })
 

--- a/src/engine/game/debugwindow.lua
+++ b/src/engine/game/debugwindow.lua
@@ -1,5 +1,5 @@
 ---@class DebugWindow : Object
----@overload fun(...) : DebugWindow
+---@overload fun(name: string, text: string, type: string, callback: fun(text: string)) : DebugWindow
 local DebugWindow, super = Class(Object)
 
 function DebugWindow:init(name, text, type, callback)

--- a/src/utils/utils.lua
+++ b/src/utils/utils.lua
@@ -2331,6 +2331,52 @@ function Utils.padString(str, len, beginning, with)
 end
 
 ---
+--- Finds and returns the scale required to print `str` with the font `font`, such that it's width does not exceed `max_width`. \
+--- If a `min_scale` is specified, strings that would have to be squished smaller than it will instead have their remaining part truncated. \
+--- Returns the input string (truncated if necessary), and the scale to print it at.
+---
+---@param str string                # The string to squish and truncate.
+---@param font love.Font            # The font being used to print the string.
+---@param max_width number          # The maximum width the string should be able to take up.
+---@param def_scale? number         # The default scale used to print the string. Defaults to `1`.
+---@param min_scale? number         # The minimum scale that the string can be squished to before being truncated.
+---@param trunc_affix? string|false # The affix added to the string during truncation. If `false`, does not add an affix. Defaults to `...`.
+---@return string result            # The truncated result. Returns the original string if it was not truncated.
+---@return number scale             # The scale the `result` string should be printed at to fit within the specified width.
+function Utils.squishAndTrunc(str, font, max_width, def_scale, min_scale, trunc_affix)
+    local scale = def_scale or 1
+    local text_width = font:getWidth(str) * scale
+
+    if text_width > max_width then
+        scale = max_width / text_width * scale
+        if min_scale and scale < min_scale then
+            scale = min_scale
+
+            local affix_width = 0
+            if trunc_affix ~= false then
+                trunc_affix = trunc_affix or "..."
+                affix_width = font:getWidth(trunc_affix) * scale
+            end
+
+            local trunc_str
+            for i=1, string.len(str) do
+                trunc_str = string.sub(str, 1, i)
+                local width = font:getWidth(trunc_str) * scale
+                if width > (max_width - affix_width) then
+                    trunc_str = string.sub(str, 1, i-1)
+                    break
+                end
+            end
+            if trunc_affix then
+                trunc_str = trunc_str .. trunc_affix
+            end
+            return trunc_str, scale
+        end
+    end
+    return str, scale
+end
+
+---
 --- Limits the specified value to be between 2 bounds, wrapping around if it exceeds it.
 ---
 ---@param val number     # The value to wrap.


### PR DESCRIPTION
Flag filtering supports two main modes - `pattern` matching and `startsWith` as well as their inverses (hide the matching flags instead) as well as filtering to show specific types
The new `mod.json` keys `defaultFlagFilterType`, `defaultFlagFIlterQuery`, and `defaultFlagFilterMode` can be set such that when the flag editor is first opened in a mod, that filter is already pre set
Adds the `Uitls.squishAndTrunc()` function for getting the scale and/or truncation of a string such that it is contained in a given width when printed in the given font - in turn the flag editor no longer has issues with entries being able to overlap if they are very long