### PR TITLE
Fix borders on ultrawide aspect ratios

### DIFF
--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -204,12 +204,18 @@ function love.load(args)
 
                 love.graphics.scale(Kristal.getGameScale())
                 Draw.setColor(1, 1, 1, dynamic and BORDER_ALPHA or 1)
+                love.graphics.push("all")
+                love.graphics.translate(
+                    ((love.graphics.getWidth()/Kristal.getGameScale())) / 2 + (((love.graphics.getHeight()/Kristal.getGameScale()) / -2) * (16/9)),
+                    ((love.graphics.getHeight()/Kristal.getGameScale()) / 2) + ((love.graphics.getHeight()/Kristal.getGameScale()) / -2)
+                )
                 if border_texture then
                     Draw.draw(border_texture, 0, 0, 0, BORDER_SCALE)
                 end
                 if dynamic then
                     Kristal.callEvent(KRISTAL_EVENT.onBorderDraw, border, border_texture)
                 end
+                love.graphics.pop()
                 Draw.setColor(1, 1, 1, 1)
                 love.graphics.reset()
             end


### PR DESCRIPTION
This does not fix aspect ratios less than 16:9. It does change the way they are broken, though.

Tested with built-in static borders, and Dark Place Legacy's dynamic borders.