### PR TITLE
Fix being unable to open mods folder with spaces in your user folder name

### DIFF
--- a/src/engine/menu/mainmenucredits.lua
+++ b/src/engine/menu/mainmenucredits.lua
@@ -42,14 +42,15 @@ function MainMenuCredits:init(menu)
                 "Dobby233Liu",
                 "FireRainV",
                 "HUECYCLES",
-                "Luna",
-                "MrOinky"
+                "Lionmeow",
+                "Luna"
             }
         },
         {
             "Kristal Engine",
             {
                 {"GitHub Contributors", COLORS.silver},
+                "MrOinky",
                 "prokube",
                 "Simbel",
                 "sjl057",
@@ -58,7 +59,6 @@ function MainMenuCredits:init(menu)
                 "TFLTV",
                 "J.A.R.U.",
                 "MCdeDaxia",
-                "",
                 ""
             },
             {

--- a/src/engine/menu/mainmenutitle.lua
+++ b/src/engine/menu/mainmenutitle.lua
@@ -80,7 +80,7 @@ function MainMenuTitle:onKeyPressed(key, is_repeat)
         elseif option == "modfolder" then
             -- FIXME: the game might freeze when using love.system.openURL to open a file directory
             if (love.system.getOS() == "Windows") then
-                os.execute("start /B "..love.filesystem.getSaveDirectory().."/mods")
+                os.execute('start /B \"\" \"'..love.filesystem.getSaveDirectory()..'/mods\"')
             else
                 love.system.openURL("file://"..love.filesystem.getSaveDirectory().."/mods")
             end


### PR DESCRIPTION
If your user folder had a name with spaces in it (For example, "Agent 7"), the "Open mods folder" button would fail to work. This fixes that by tweaking the command slightly.
I'm also adding Lionmeow to the contributor list because she bashed her head against a wall to help me figure out why the obvious solution of "just add escaped double quotes" wasn't working.