### PR TITLE
set `mod_rebind` gamepad default to `gamepad:x`

### DIFF
--- a/src/engine/input.lua
+++ b/src/engine/input.lua
@@ -227,7 +227,7 @@ function Input.resetBinds(gamepad, mod_id)
             ["debug_menu"] = {},
             ["object_selector"] = {},
             ["fast_forward"] = {},
-            ["mod_rebind"] = {},
+            ["mod_rebind"] = {"gamepad:x"},
         }
         if gamepad ~= true then Utils.merge(Input.key_bindings, key_bindings) end
         if gamepad ~= false then Utils.merge(Input.gamepad_bindings, gamepad_bindings) end
@@ -324,7 +324,7 @@ function Input.resetBinds(gamepad, mod_id)
             ["debug_menu"] = {},
             ["object_selector"] = {},
             ["fast_forward"] = {},
-            ["mod_rebind"] = {},
+            ["mod_rebind"] = {"gamepad:x"},
         }
         for _,mod in ipairs(Kristal.Mods.getMods()) do
             if mod.keybinds then


### PR DESCRIPTION
Silly me forgot to add a default bind for the controls button in the mod menu on the gamepad, this sets the default binding to `gamepad:x` as it probably makes sense for this to be bound by default?