### PR TITLE
Added self.background_speed for shops

### DIFF
--- a/mods/example/scripts/shops/mousehole.lua
+++ b/mods/example/scripts/shops/mousehole.lua
@@ -31,6 +31,7 @@ function MouseHole:init()
     self.sell_options_text["storage"] = "Let's see what ya got."
 
     self.background = "shops/mousehole_background"
+    self.background_speed = 5/30
 
     self.shopkeeper:setActor("shopkeepers/amelia")
     self.shopkeeper.sprite:setPosition(0, 8)
@@ -48,7 +49,6 @@ end
 
 function MouseHole:postInit()
     super.postInit(self)
-    self.background_sprite:play(5/30, true)
     self.shopkeeper:setLayer(SHOP_LAYERS["above_boxes"])
 end
 

--- a/src/engine/game/shop.lua
+++ b/src/engine/game/shop.lua
@@ -172,6 +172,7 @@ function Shop:init()
     end
 
     self.background = nil
+    self.background_speed = 5/30
 
     self.state = "NONE"
     self.state_reason = nil
@@ -251,7 +252,7 @@ function Shop:postInit()
         self.background_sprite = Sprite(self.background, 0, 0)
         self.background_sprite:setScale(2, 2)
         self.background_sprite.layer = SHOP_LAYERS["background"]
-        self.background_sprite:play(self.background_speed or 5/30, true)
+        self.background_sprite:play(self.background_speed, true)
         self:addChild(self.background_sprite)
     end
 

--- a/src/engine/game/shop.lua
+++ b/src/engine/game/shop.lua
@@ -57,6 +57,7 @@
 ---
 ---@field background                string      The filepath of the background texture for this shop, relative to `assets/sprites`
 ---@field background_sprite         Sprite      The Sprite instance used to control the background. Not defined in `Shop:init()`.
+---@field background_speed          number      The animation speed of the background texture.
 ---
 ---@field shop_music                string      The filepath of the song to play in this shop, relative to `assets/music`
 ---@field music                     Music       The `Music` instance used to control the shop's music
@@ -170,7 +171,7 @@ function Shop:init()
         }
     end
 
-    self.background = "ui/shop/bg_seam"
+    self.background = nil
 
     self.state = "NONE"
     self.state_reason = nil
@@ -250,6 +251,7 @@ function Shop:postInit()
         self.background_sprite = Sprite(self.background, 0, 0)
         self.background_sprite:setScale(2, 2)
         self.background_sprite.layer = SHOP_LAYERS["background"]
+        self.background_sprite:play(self.background_speed or 5/30, true)
         self:addChild(self.background_sprite)
     end
 


### PR DESCRIPTION
Sets the animation speed of the background, defaults to 5/30.