### PR TITLE
Fill tension debug hotkey in the overworld

### DIFF
--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -2959,9 +2959,7 @@ function Battle:onKeyPressed(key)
             self.soul.collidable = false
         end
         if key == "b" then
-            for _,battler in ipairs(self.party) do
-                battler:hurt(math.huge)
-            end
+            self:hurt(math.huge, true, "ALL")
         end
         if key == "k" then
             Game:setTension(Game:getMaxTension() * 2, true)

--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -379,6 +379,9 @@ function World:onKeyPressed(key)
         if key == "b" then
             Game.world:hurtParty(math.huge)
         end
+        if key == "k" then
+            Game:setTension(Game:getMaxTension() * 2, true)
+        end
         if key == "n" then
             NOCLIP = not NOCLIP
         end


### PR DESCRIPTION
You can cast spells in the overworld in some scenarios (like Heal Prayer), there should be an easier way to fill your tension to test them. Uses Ctrl+K (like in battles).