### PR TITLE
Use `getScreenPos()` for `bullet.remove_offscreen`

### DIFF
--- a/src/engine/game/battle/bullet.lua
+++ b/src/engine/game/battle/bullet.lua
@@ -140,7 +140,8 @@ function Bullet:update()
 
     if self.remove_offscreen then
         local size = self.width + self.height
-        if self.x < -size or self.y < -size or self.x > SCREEN_WIDTH + size or self.y > SCREEN_HEIGHT + size then
+        local x, y = self:getScreenPos()
+        if x < -size or y < -size or x > SCREEN_WIDTH + size or y > SCREEN_HEIGHT + size then
             self:remove()
         end
     end


### PR DESCRIPTION
Offscreen checks for `bullet.remove_offscreen` used the bullet's own `x` and `y` values rather than their screen position, which means that `remove_offscreen` could remove bullets that were onscreen if their (0,0) was not the top left of the screen (e.g. if the bullet is parented to something that's not at (0,0) itself)