### PR TITLE
fix console polluting _G

### DIFF
--- a/src/engine/game/console.lua
+++ b/src/engine/game/console.lua
@@ -359,8 +359,8 @@ end
 function Console:unsafeRun(str)
     local chunk, err = loadstring(str)
     if chunk then
-        self.env.selected = Kristal.DebugSystem.object
-        self.env["_"] = Kristal.DebugSystem.object
+        rawset(self.env, "selected", Kristal.DebugSystem.object)
+        rawset(self.env, "_", Kristal.DebugSystem.object)
         setfenv(chunk,self.env)
         self:push(chunk())
     else


### PR DESCRIPTION
Console:unsafeRun also sets `_` and `selected` in the global table in addition to the console `env` when it is called, switched indexing to `rawset` to bypass this
discord bug reported here: https://discord.com/channels/899153719248191538/1334310146872184872