### PR TITLE
Removed spells will no longer prevent you from loading a save

### DIFF
--- a/src/engine/game/common/data/partymember.lua
+++ b/src/engine/game/common/data/partymember.lua
@@ -857,7 +857,11 @@ end
 function PartyMember:loadSpells(data)
     self.spells = {}
     for _,v in ipairs(data) do
-        self:addSpell(v)
+        if Registry.getSpell(v) then
+            self:addSpell(v)
+        else
+            Kristal.Console:error("Could not load spell \"".. (v or "nil") .."\"")
+        end
     end
 end
 


### PR DESCRIPTION
It will just print an error to the console instead, like with removed items and party members.