### PR TITLE
Add emergency restart bind to errorhandler

### DIFF
--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -847,6 +847,8 @@ function Kristal.errorHandler(msg)
                 else
                     return "reload"
                 end
+            elseif e == "keypressed" and a == "r" and love.keyboard.isDown("lctrl", "rctrl") then
+                return "restart"
             elseif e == "keypressed" and a == "c" and love.keyboard.isDown("lctrl", "rctrl") and not critical then
                 copyToClipboard()
             elseif e == "touchpressed" then


### PR DESCRIPTION
For those times where you create an error loop that can't be fixed without a hard reset (i do this too often)
The bind for this is `CTRL+R` (i wanted `CTRL+Esc` but windows uses it...) 