### PR TITLE
Fix multiple hook files on the same object (across libraries) discarding each other

### DIFF
--- a/src/engine/registry.lua
+++ b/src/engine/registry.lua
@@ -920,7 +920,7 @@ function Registry.iterScripts(base_path, exclude_folder)
     local result = {}
 
     CLASS_NAME_GETTER = function(k)
-        for _,v in ipairs(result) do
+        for _,v in ipairs(Utils.reverse(result)) do
             if v.id == k then
                 return v.out[1]
             end


### PR DESCRIPTION
this bug has tortured me for far too long and i finally realised what the issue is!!!

Whenever the registry processed hook files it temporarily overwrote the `CLASS_NAME_GETTER` so that newly hooked files were taken into account - however it did an oopsie and returned the *first* match it found, which is the first thing that hooked over it meaning only the first and last hook counted. Whoops!

this PR just reverses the order it reads through hooks so it'll get the most recently applied hook instead of the oldest, meaning all library hooks now apply! 🥳 