### PR TITLE
Support for loading Tiled polygon shapes as Event collision

### DIFF
--- a/mods/_testmod/scripts/world/events/banana.lua
+++ b/mods/_testmod/scripts/world/events/banana.lua
@@ -1,7 +1,7 @@
 local Banana, super = Class(Event)
 
 function Banana:init(data)
-    super.init(self, data.center_x, data.center_y, data.width, data.height)
+    super.init(self, data.center_x, data.center_y, {data.width, data.height})
 
     self:setOrigin(0.5, 0.5)
     self:setSprite("banana", 0.25)

--- a/mods/_testmod/scripts/world/events/darkdoor.lua
+++ b/mods/_testmod/scripts/world/events/darkdoor.lua
@@ -1,7 +1,7 @@
 local DarkDoor, super = Class(Event)
 
 function DarkDoor:init(data)
-    super.init(self, data.center_x, data.center_y, data.width, data.height)
+    super.init(self, data.center_x, data.center_y, {data.width, data.height})
 
     self:setOrigin(0.5, 0.5)
     self:setSprite("darkdoor_closed")

--- a/mods/_testmod/scripts/world/maps/alley2/alley2.tmx
+++ b/mods/_testmod/scripts/world/maps/alley2/alley2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.9" tiledversion="1.9.0" orientation="orthogonal" renderorder="right-down" width="30" height="40" tilewidth="40" tileheight="40" infinite="0" nextlayerid="11" nextobjectid="120">
+<map version="1.9" tiledversion="1.9.0" orientation="orthogonal" renderorder="right-down" width="30" height="40" tilewidth="40" tileheight="40" infinite="0" nextlayerid="11" nextobjectid="122">
  <editorsettings>
   <export target="data.lua" format="lua"/>
  </editorsettings>
@@ -205,6 +205,7 @@
    <properties>
     <property name="lock" type="bool" value="false"/>
    </properties>
+   <polygon points="0,0 160,0 160,280 0,280"/>
   </object>
   <object id="90" name="cameratarget" x="480" y="1200" width="240" height="240">
    <properties>

--- a/mods/_testmod/scripts/world/maps/alley2/data.lua
+++ b/mods/_testmod/scripts/world/maps/alley2/data.lua
@@ -10,7 +10,7 @@ return {
   tilewidth = 40,
   tileheight = 40,
   nextlayerid = 11,
-  nextobjectid = 120,
+  nextobjectid = 122,
   properties = {
     ["border"] = "city",
     ["light"] = false,
@@ -944,13 +944,19 @@ return {
           id = 69,
           name = "slidearea",
           class = "",
-          shape = "rectangle",
+          shape = "polygon",
           x = 520,
           y = 920,
           width = 160,
           height = 280,
           rotation = 0,
           visible = true,
+          polygon = {
+            { x = 0, y = 0 },
+            { x = 160, y = 0 },
+            { x = 160, y = 280 },
+            { x = 0, y = 280 }
+          },
           properties = {
             ["lock"] = false
           }

--- a/mods/_testmod/scripts/world/maps/alley3.lua
+++ b/mods/_testmod/scripts/world/maps/alley3.lua
@@ -378,13 +378,19 @@ return {
           id = 4,
           name = "transition",
           class = "",
-          shape = "rectangle",
+          shape = "polygon",
           x = -40,
           y = 240,
           width = 40,
           height = 80,
           rotation = 0,
           visible = true,
+          polygon = {
+            { x = -10, y = -40 },
+            { x = 40, y = 0 },
+            { x = 40, y = 80 },
+            { x = -10, y = 40 }
+          },
           properties = {
             ["map"] = "alley2",
             ["marker"] = "entry_right"

--- a/mods/_testmod/scripts/world/maps/alley3.tmx
+++ b/mods/_testmod/scripts/world/maps/alley3.tmx
@@ -80,6 +80,7 @@
     <property name="map" value="alley2"/>
     <property name="marker" value="entry_right"/>
    </properties>
+   <polygon points="-10,-40 40,0 40,80 -10,40"/>
   </object>
   <object id="14" name="forcefield" x="200" y="200" width="40" height="160">
    <properties>

--- a/mods/_testmod/scripts/world/maps/alley4.lua
+++ b/mods/_testmod/scripts/world/maps/alley4.lua
@@ -10,7 +10,7 @@ return {
   tilewidth = 40,
   tileheight = 40,
   nextlayerid = 15,
-  nextobjectid = 123,
+  nextobjectid = 126,
   properties = {},
   tilesets = {
     {
@@ -296,19 +296,6 @@ return {
           rotation = 0,
           visible = true,
           properties = {}
-        },
-        {
-          id = 120,
-          name = "THIS EVIL GOD DAMN POINT",
-          class = "",
-          shape = "point",
-          x = 640,
-          y = 340,
-          width = 0,
-          height = 0,
-          rotation = 0,
-          visible = true,
-          properties = {}
         }
       }
     },
@@ -414,6 +401,33 @@ return {
           gid = 262,
           visible = true,
           properties = {}
+        },
+        {
+          id = 123,
+          name = "interactable",
+          class = "",
+          shape = "polygon",
+          x = 480,
+          y = 360,
+          width = 0,
+          height = 0,
+          rotation = 0,
+          visible = true,
+          polygon = {
+            { x = 0, y = 0 },
+            { x = -40, y = 0 },
+            { x = 80, y = -40 },
+            { x = 200, y = 0 },
+            { x = 160, y = 0 },
+            { x = 160, y = 80 },
+            { x = 0, y = 80 }
+          },
+          properties = {
+            ["solid"] = true,
+            ["text1_1"] = "* Check it out,[wait:5] i'm[wait:3] house",
+            ["text1_2"] = "* House[wait:5] like[wait:5] car[wait:3]pet",
+            ["text2_1"] = "* Chicken"
+          }
         }
       }
     },

--- a/mods/_testmod/scripts/world/maps/alley4.tmx
+++ b/mods/_testmod/scripts/world/maps/alley4.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.9" tiledversion="1.9.0" orientation="orthogonal" renderorder="right-down" width="31" height="17" tilewidth="40" tileheight="40" infinite="0" nextlayerid="15" nextobjectid="123">
+<map version="1.9" tiledversion="1.9.0" orientation="orthogonal" renderorder="right-down" width="31" height="17" tilewidth="40" tileheight="40" infinite="0" nextlayerid="15" nextobjectid="126">
  <editorsettings>
   <export target="alley4.lua" format="lua"/>
  </editorsettings>
@@ -57,9 +57,6 @@
   <object id="118" name="MARKERFOUR" x="160" y="400">
    <point/>
   </object>
-  <object id="120" name="THIS EVIL GOD DAMN POINT" x="640" y="340">
-   <point/>
-  </object>
  </objectgroup>
  <objectgroup color="#ff00ff" id="2" name="objects">
   <object id="4" name="transition" x="1240" y="360" width="40" height="80">
@@ -96,6 +93,15 @@
    </properties>
   </object>
   <object id="122" gid="262" x="1060" y="580" width="40" height="40"/>
+  <object id="123" name="interactable" x="480" y="360">
+   <properties>
+    <property name="solid" type="bool" value="true"/>
+    <property name="text1_1" value="* Check it out,[wait:5] i'm[wait:3] house"/>
+    <property name="text1_2" value="* House[wait:5] like[wait:5] car[wait:3]pet"/>
+    <property name="text2_1" value="* Chicken"/>
+   </properties>
+   <polygon points="0,0 -40,0 80,-40 200,0 160,0 160,80 0,80"/>
+  </object>
  </objectgroup>
  <layer id="13" name="Tile Layer 2" width="31" height="17">
   <data encoding="csv">

--- a/mods/_testmod/scripts/world/maps/fountain.lua
+++ b/mods/_testmod/scripts/world/maps/fountain.lua
@@ -1,7 +1,7 @@
 return {
   version = "1.9",
   luaversion = "5.1",
-  tiledversion = "1.9.1",
+  tiledversion = "1.9.0",
   class = "",
   orientation = "orthogonal",
   renderorder = "right-down",
@@ -10,7 +10,7 @@ return {
   tilewidth = 40,
   tileheight = 40,
   nextlayerid = 6,
-  nextobjectid = 5,
+  nextobjectid = 6,
   properties = {},
   tilesets = {},
   layers = {

--- a/mods/_testmod/scripts/world/maps/fountain.tmx
+++ b/mods/_testmod/scripts/world/maps/fountain.tmx
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.9" tiledversion="1.9.1" orientation="orthogonal" renderorder="right-down" width="16" height="12" tilewidth="40" tileheight="40" infinite="0" nextlayerid="6" nextobjectid="5">
+<map version="1.9" tiledversion="1.9.0" orientation="orthogonal" renderorder="right-down" width="16" height="12" tilewidth="40" tileheight="40" infinite="0" nextlayerid="6" nextobjectid="6">
+ <editorsettings>
+  <export target="fountain.lua" format="lua"/>
+ </editorsettings>
  <layer id="1" name="Tile Layer 1" width="16" height="12">
   <data encoding="csv">
 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,

--- a/src/engine/game/world/event.lua
+++ b/src/engine/game/world/event.lua
@@ -19,25 +19,26 @@
 ---@overload fun(data: table) : Event
 local Event, super = Class(Object)
 
+
 ---@param x number
 ---@param y number
----@param w number
----@param h number
----@param size table
+---@param shape table
 ---@param data table
----@overload fun(self: Event, x: number, y: number, size: table)
 ---@overload fun(self: Event, data: table)
-function Event:init(x, y, w, h)
+function Event:init(x, y, shape)
+    shape = shape or {0, 0}
     if type(x) == "table" then
         local data = x
         x, y = data.x, data.y
-        w, h = data.width, data.height
-    elseif type(w) == "table" then
-        local data = w
-        w, h = data.width, data.height
+        shape[1], shape[2] = data.width, data.height
+        shape[3] = data.polygon
     end
 
-    super.init(self, x, y, w, h)
+    super.init(self, x, y, shape[1], shape[2])
+
+    if shape[3] then
+        self.collider = Utils.colliderFromShape(self, {shape = "polygon", polygon = shape[3]})
+    end
 
     -- Default collider (Object width and height)
     self._default_collider = Hitbox(self, 0, 0, self.width, self.height)

--- a/src/engine/game/world/event.lua
+++ b/src/engine/game/world/event.lua
@@ -14,15 +14,13 @@
 ---@field unique_id         string
 ---@field world             World       The world that this event is contained in
 ---
----@overload fun(x: number, y: number, w: number, h: number) : Event
----@overload fun(x: number, y: number, size: table) : Event
+---@overload fun(x: number, y: number, shape: table) : Event
 ---@overload fun(data: table) : Event
 local Event, super = Class(Object)
 
-
 ---@param x number
 ---@param y number
----@param shape table
+---@param shape {[1]: number, [2]: number, [3]: table?} Shape data for this event. First two indexes are the width and height of the object. The third (optional) index is polygon data.
 ---@param data table
 ---@overload fun(self: Event, data: table)
 function Event:init(x, y, shape)

--- a/src/engine/game/world/events/cameratarget.lua
+++ b/src/engine/game/world/events/cameratarget.lua
@@ -24,8 +24,8 @@
 ---@overload fun(...) : CameraTarget
 local CameraTarget, super = Class(Event)
 
-function CameraTarget:init(x, y, w, h, properties)
-    super.init(self, x, y, w, h)
+function CameraTarget:init(x, y, shape, properties)
+    super.init(self, x, y, shape)
 
     self.solid = false
 

--- a/src/engine/game/world/events/forcefield.lua
+++ b/src/engine/game/world/events/forcefield.lua
@@ -20,8 +20,8 @@
 ---@overload fun(...) : Forcefield
 local Forcefield, super = Class(Event)
 
-function Forcefield:init(x, y, w, h, properties)
-    super.init(self, x, y, w, h)
+function Forcefield:init(x, y, shape, properties)
+    super.init(self, x, y, shape)
 
     self.end_sprite = Assets.getFramesOrTexture("world/events/forcefield/end")
     self.middle_sprite = Assets.getFramesOrTexture("world/events/forcefield/middle")

--- a/src/engine/game/world/events/fountainfloor.lua
+++ b/src/engine/game/world/events/fountainfloor.lua
@@ -10,8 +10,8 @@
 ---@overload fun(...) : FountainFloor
 local FountainFloor, super = Class(Event)
 
-function FountainFloor:init(x, y, width, height)
-    super.init(self, x, y, width, height)
+function FountainFloor:init(x, y, shape)
+    super.init(self, x, y, shape)
 
     self:setColor(0, 1, 0)
 

--- a/src/engine/game/world/events/hideparty.lua
+++ b/src/engine/game/world/events/hideparty.lua
@@ -10,8 +10,8 @@
 ---@overload fun(...) : HideParty
 local HideParty, super = Class(Event)
 
-function HideParty:init(x, y, w, h, alpha)
-    super.init(self, x, y, w, h)
+function HideParty:init(x, y, shape, alpha)
+    super.init(self, x, y, shape)
 
     self.alphas = {}
     self.target_alpha = alpha or 0

--- a/src/engine/game/world/events/interactable.lua
+++ b/src/engine/game/world/events/interactable.lua
@@ -23,8 +23,9 @@
 ---@overload fun(...) : Interactable
 local Interactable, super = Class(Event)
 
-function Interactable:init(x, y, width, height, properties)
-    super.init(self, x, y, width or TILE_WIDTH, height or TILE_HEIGHT)
+function Interactable:init(x, y, shape, properties)
+    shape = shape or {TILE_WIDTH, TILE_HEIGHT}
+    super.init(self, x, y, shape)
 
     properties = properties or {}
 

--- a/src/engine/game/world/events/magicglass.lua
+++ b/src/engine/game/world/events/magicglass.lua
@@ -14,8 +14,8 @@
 ---@overload fun(...) : MagicGlass
 local MagicGlass, super = Class(Event)
 
-function MagicGlass:init(x, y, w, h)
-    super.init(self, x, y, w, h)
+function MagicGlass:init(x, y, shape)
+    super.init(self, x, y, shape)
 
     self.texture = Assets.getTexture("world/events/magical_glass")
 

--- a/src/engine/game/world/events/mirror.lua
+++ b/src/engine/game/world/events/mirror.lua
@@ -12,8 +12,8 @@
 ---@overload fun(...) : MirrorArea
 local MirrorArea, super = Class(Event)
 
-function MirrorArea:init(x, y, w, h, properties)
-    super.init(self, x, y, w, h)
+function MirrorArea:init(x, y, shape, properties)
+    super.init(self, x, y, shape)
 
     properties = properties or {}
 

--- a/src/engine/game/world/events/outline.lua
+++ b/src/engine/game/world/events/outline.lua
@@ -10,8 +10,8 @@
 ---@overload fun(...) : Outline
 local Outline, super = Class(Event)
 
-function Outline:init(x, y, w, h)
-    super.init(self, x, y, w, h)
+function Outline:init(x, y, shape)
+    super.init(self, x, y, shape)
 
     self.solid = false
 

--- a/src/engine/game/world/events/pushblock.lua
+++ b/src/engine/game/world/events/pushblock.lua
@@ -30,8 +30,8 @@
 ---@overload fun(...) : PushBlock
 local PushBlock, super = Class(Event)
 
-function PushBlock:init(x, y, w, h, properties, sprite, solved_sprite)
-    super.init(self, x, y, w, h)
+function PushBlock:init(x, y, shape, properties, sprite, solved_sprite)
+    super.init(self, x, y, shape)
 
     properties = properties or {}
 

--- a/src/engine/game/world/events/quicksave.lua
+++ b/src/engine/game/world/events/quicksave.lua
@@ -9,8 +9,8 @@
 ---@overload fun(...) : QuicksaveEvent
 local QuicksaveEvent, super = Class(Event)
 
-function QuicksaveEvent:init(x, y, w, h, marker)
-    super.init(self, x, y, w, h)
+function QuicksaveEvent:init(x, y, shape, marker)
+    super.init(self, x, y, shape)
     self.marker = marker
 end
 

--- a/src/engine/game/world/events/savepoint.lua
+++ b/src/engine/game/world/events/savepoint.lua
@@ -17,7 +17,7 @@
 local Savepoint, super = Class(Interactable)
 
 function Savepoint:init(x, y, properties)
-    super.init(self, x, y, nil, nil, properties)
+    super.init(self, x, y, nil, properties)
 
     properties = properties or {}
 

--- a/src/engine/game/world/events/script.lua
+++ b/src/engine/game/world/events/script.lua
@@ -17,8 +17,8 @@
 ---@overload fun(...) : Script
 local Script, super = Class(Event)
 
-function Script:init(x, y, w, h, properties)
-    super.init(self, x, y, w, h)
+function Script:init(x, y, shape, properties)
+    super.init(self, x, y, shape)
 
     properties = properties or {}
 

--- a/src/engine/game/world/events/setflagevent.lua
+++ b/src/engine/game/world/events/setflagevent.lua
@@ -11,8 +11,8 @@
 ---@overload fun(...) : SetFlagEvent
 local SetFlagEvent, super = Class(Event, "setflag")
 
-function SetFlagEvent:init(x, y, width, height, properties)
-    super.init(self, x, y, width, height)
+function SetFlagEvent:init(x, y, shape, properties)
+    super.init(self, x, y, shape)
 
     properties = properties or {}
 

--- a/src/engine/game/world/events/silhouette.lua
+++ b/src/engine/game/world/events/silhouette.lua
@@ -7,8 +7,8 @@
 ---@overload fun(...) : Silhouette
 local Silhouette, super = Class(Event)
 
-function Silhouette:init(x, y, w, h)
-    super.init(self, x, y, w, h)
+function Silhouette:init(x, y, shape)
+    super.init(self, x, y, shape)
 
     self.solid = false
 end

--- a/src/engine/game/world/events/slidearea.lua
+++ b/src/engine/game/world/events/slidearea.lua
@@ -10,8 +10,8 @@
 ---@overload fun(...) : SlideArea
 local SlideArea, super = Class(Event)
 
-function SlideArea:init(x, y, w, h, properties)
-    super.init(self, x, y, w, h)
+function SlideArea:init(x, y, shape, properties)
+    super.init(self, x, y, shape)
 
     self.lock_movement = properties["lock"] or false
 end

--- a/src/engine/game/world/events/tilebutton.lua
+++ b/src/engine/game/world/events/tilebutton.lua
@@ -29,8 +29,8 @@
 ---@overload fun(...) : TileButton
 local TileButton, super = Class(Event)
 
-function TileButton:init(x, y, w, h, properties, idle_sprite, pressed_sprite)
-    super.init(self, x, y, w, h)
+function TileButton:init(x, y, shape, properties, idle_sprite, pressed_sprite)
+    super.init(self, x, y, shape)
 
     self.idle_sprite = properties["sprite"] or idle_sprite or "world/events/glowtile/idle"
     self.pressed_sprite = properties["pressedsprite"] or properties["sprite"] or pressed_sprite or idle_sprite or "world/events/glowtile/pressed"

--- a/src/engine/game/world/events/tileobject.lua
+++ b/src/engine/game/world/events/tileobject.lua
@@ -24,7 +24,7 @@ local TileObject, super = Class(Event)
 function TileObject:init(tileset, tile, x, y, w, h, rotation, flip_x, flip_y)
     local tile_width, tile_height = tileset:getTileSize(tile)
 
-    super.init(self, x, y, w or self.tile_width, h or self.tile_height)
+    super.init(self, x, y, {w or self.tile_width, h or self.tile_height})
 
     self.tileset = tileset
     self.tile = tile

--- a/src/engine/game/world/events/transition.lua
+++ b/src/engine/game/world/events/transition.lua
@@ -25,8 +25,8 @@
 ---@overload fun(...) : Transition
 local Transition, super = Class(Event)
 
-function Transition:init(x, y, w, h, properties)
-    super.init(self, x, y, w, h)
+function Transition:init(x, y, shape, properties)
+    super.init(self, x, y, shape)
 
     properties = properties or {}
 

--- a/src/engine/game/world/map.lua
+++ b/src/engine/game/world/map.lua
@@ -573,6 +573,22 @@ function Map:loadObjects(layer, depth, layer_type)
         v.center_x = v.x + v.width/2
         v.center_y = v.y + v.height/2
 
+        -- Get width/height of the full polygon (usable when a polygon is not supported on an object)
+        if v.polygon then
+            local min_x, max_x, min_y, max_y = 0, 0, 0, 0
+            for _, point in ipairs(v.polygon) do
+                min_x = math.min(point.x, min_x)
+                max_x = math.max(point.x, max_x)
+                min_y = math.min(point.y, min_y)
+                max_y = math.max(point.y, max_y)
+            end
+
+            v.width = max_x - min_x
+            v.height = max_y - min_y
+            v.center_x = v.x - min_x + v.width/2
+            v.center_y = v.y - min_y + v.height/2
+        end
+
         if v.gid then
             local tx,ty,tw,th = self:getTileObjectRect(v)
             v.center_x = tx + tw/2
@@ -690,53 +706,59 @@ function Map:loadObject(name, data)
         chara_x = tx + tw/2
         chara_y = ty + th
     end
+
+    local shape_data = {data.width, data.height, data.polygon}
+
+    local rect_data = Utils.copy(shape_data)
+    rect_data[3] = nil
+
     -- Kristal object loading
     if name:lower() == "savepoint" then
         return Savepoint(data.center_x, data.center_y, data.properties)
     elseif name:lower() == "interactable" then
-        return Interactable(data.x, data.y, data.width, data.height, data.properties)
+        return Interactable(data.x, data.y, shape_data, data.properties)
     elseif name:lower() == "script" then
-        return Script(data.x, data.y, data.width, data.height, data.properties)
+        return Script(data.x, data.y, shape_data, data.properties)
     elseif name:lower() == "transition" then
-        return Transition(data.x, data.y, data.width, data.height, data.properties)
+        return Transition(data.x, data.y, shape_data, data.properties)
     elseif name:lower() == "npc" then
         return NPC(data.properties["actor"], chara_x, chara_y, data.properties)
     elseif name:lower() == "enemy" then
         return ChaserEnemy(data.properties["actor"], chara_x, chara_y, data.properties)
     elseif name:lower() == "outline" then
-        return Outline(data.x, data.y, data.width, data.height)
+        return Outline(data.x, data.y, rect_data)
     elseif name:lower() == "silhouette" then
-        return Silhouette(data.x, data.y, data.width, data.height)
+        return Silhouette(data.x, data.y, rect_data)
     elseif name:lower() == "slidearea" then
-        return SlideArea(data.x, data.y, data.width, data.height, data.properties)
+        return SlideArea(data.x, data.y, rect_data, data.properties)
     elseif name:lower() == "mirror" then
-        return MirrorArea(data.x, data.y, data.width, data.height, data.properties)
+        return MirrorArea(data.x, data.y, rect_data, data.properties)
     elseif name:lower() == "chest" then
         return TreasureChest(data.center_x, data.center_y, data.properties)
     elseif name:lower() == "cameratarget" then
-        return CameraTarget(data.x, data.y, data.width, data.height, data.properties)
+        return CameraTarget(data.x, data.y, shape_data, data.properties)
     elseif name:lower() == "hideparty" then
-        return HideParty(data.x, data.y, data.width, data.height, data.properties.alpha)
+        return HideParty(data.x, data.y, shape_data, data.properties.alpha)
     elseif name:lower() == "setflag" then
-        return SetFlagEvent(data.x, data.y, data.width, data.height, data.properties)
+        return SetFlagEvent(data.x, data.y, shape_data, data.properties)
     elseif name:lower() == "cybertrash" then
         return CyberTrashCan(data.center_x, data.center_y, data.properties)
     elseif name:lower() == "forcefield" then
-        return Forcefield(data.x, data.y, data.width, data.height, data.properties)
+        return Forcefield(data.x, data.y, rect_data, data.properties)
     elseif name:lower() == "pushblock" then
-        return PushBlock(data.x, data.y, data.width, data.height, data.properties)
+        return PushBlock(data.x, data.y, rect_data, data.properties)
     elseif name:lower() == "tilebutton" then
-        return TileButton(data.x, data.y, data.width, data.height, data.properties)
+        return TileButton(data.x, data.y, rect_data, data.properties)
     elseif name:lower() == "magicglass" then
-        return MagicGlass(data.x, data.y, data.width, data.height)
+        return MagicGlass(data.x, data.y, rect_data)
     elseif name:lower() == "warpdoor" then
         return WarpDoor(data.x, data.y, data.properties)
     elseif name:lower() == "darkfountain" then
         return DarkFountain(data.x, data.y)
     elseif name:lower() == "fountainfloor" then
-        return FountainFloor(data.x, data.y, data.width, data.height)
+        return FountainFloor(data.x, data.y, rect_data)
     elseif name:lower() == "quicksave" then
-        return QuicksaveEvent(data.x, data.y, data.width, data.height, data.properties["marker"])
+        return QuicksaveEvent(data.x, data.y, shape_data, data.properties["marker"])
     elseif name:lower() == "sprite" then
         local sprite = Sprite(data.properties["texture"], data.x, data.y)
         sprite:play(data.properties["speed"], true)


### PR DESCRIPTION
This PR allows for event colliders to take the form of Tiled polygons in maps. Custom events should automatically support this feature, and most collision-based Kristal events will support polygons too. Events that do not support polygons will turn into rectangles ingame if placed as a polygon (rather than the previous single-pixel hitbox).

(This does not add polygon support for most graphical events e.g. mirrors, silhouettes, outlines, as they rely on canvases, not collision)

### This PR includes breaking changes:
- The `Event` constructor `Event(x, y, w, h)` has been removed. `Event(x, y, shape)` must be used instead.
- As well as changing the constructor for `Event`, all Kristal event constructors that used an `x, y, w, h, properties` format of constructor now use `x, y, shape, properties`.

The error `Attempt to index local "shape" (a number value)` will appear when loading an event impacted by this breaking change.

### Quick fixes for breaking changes:
- If you have overriden `Event` or any base kristal event that previously used width and height (`w, h,`) in it's `init`, replace them with `shape,`. 
- If you used the `w` or `h` of the above `init` functions in your own code they should be replaced with `shape[1]` and `shape[2]` respectively.
- Custom events (files in `scripts/world/events`) that used any of the changed or removed `x, y, w, h` format event constructors for `super.init()` should switch to `x, y, shape` - `shape` is `w` and `h` as a single table, plus `data.polygon` as a third element for polygon support (e.g. `{w, h, data.polygon}`). 

(In short: turn widths and heights into the `shape` table, which is `{width, height, polygon}` if you have to create it manually. `polygon` data comes from `data.polygon` in this case).

### Non-breaking changes:
- Events can now load with polygon shaped collision from map data. 
- The `Event(x, y, size)` constructor is now `Event(x, y, shape)`. Previous usage of this constructor works as usual, but `shape` may also contain polygon data to read in the third index.
- Events which cannot use polygons now use a rectangle that encases the entire area of the polygon rather than a single pixel.