### PR TITLE
Add `Ctrl+Alt+Shift+R` to error handler

### DIFF
--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -847,6 +847,8 @@ function Kristal.errorHandler(msg)
                 else
                     return "reload"
                 end
+            elseif e == "keypressed" and a == "r" and love.keyboard.isDown("lctrl", "rctrl") and love.keyboard.isDown("lalt", "ralt") and love.keyboard.isDown("lshift", "rshift") then
+                return "restart"
             elseif e == "keypressed" and a == "c" and love.keyboard.isDown("lctrl", "rctrl") and not critical then
                 copyToClipboard()
             elseif e == "touchpressed" then


### PR DESCRIPTION
As an incredibly silly person i closed #339 thinking that the global `Ctrl+Alt+Shift+R` worked in the errorhandler after discovering that it already existed engine-wide - however the errorhandler was actually the one exemption for this! Double oopsies...

This PR makes the `Ctrl+Alt+Shift+R` emergency restart bind also usable in the error handler for those times you get stuck in a crash loop.