### PR TITLE
FrozenEnemy Crash Fix

### DIFF
--- a/src/engine/game/world/event.lua
+++ b/src/engine/game/world/event.lua
@@ -18,14 +18,14 @@
 ---@overload fun(data: table) : Event
 local Event, super = Class(Object)
 
----@param x number
----@param y number
----@param width number
----@param height number
----@param shape {[1]: number, [2]: number, [3]: table?} Shape data for this event. First two indexes are the width and height of the object. The third (optional) index is polygon data.
----@param data table
----@overload fun(self: Event, data: table)
----@overload fun(self: Event, x: number, y: number, shape: {[1]: number, [2]: number, [3]: table?})
+---@param x?        number
+---@param y?        number
+---@param width?    number
+---@param height?   number
+---@param shape?    {[1]: number, [2]: number, [3]: table?} Shape data for this event. First two indexes are the width and height of the object. The third (optional) index is polygon data.
+---@param data?     table
+---@overload fun(self: Event, data?: table)
+---@overload fun(self: Event, x?: number, y?: number, shape?: {[1]: number, [2]: number, [3]: table?})
 function Event:init(x, y, width, height)
     local shape = {0,0}
     if type(width) == "table" then

--- a/src/engine/game/world/events/interactable.lua
+++ b/src/engine/game/world/events/interactable.lua
@@ -23,6 +23,10 @@
 ---@overload fun(...) : Interactable
 local Interactable, super = Class(Event)
 
+---@param x?            number
+---@param y?            number
+---@param shape?        { [1]: number, [2]: number, [3]: table? }
+---@param properties?   table
 function Interactable:init(x, y, shape, properties)
     shape = shape or {TILE_WIDTH, TILE_HEIGHT}
     super.init(self, x, y, shape)

--- a/src/engine/game/world/frozenenemy.lua
+++ b/src/engine/game/world/frozenenemy.lua
@@ -22,7 +22,7 @@ function FrozenEnemy:init(actor, x, y, properties)
         actor = Registry.createActor(actor)
     end
     local w, h = actor:getSize()
-    super.init(self, x, y, w, h, properties)
+    super.init(self, x, y, {w, h}, properties)
 
     properties = properties or {}
 


### PR DESCRIPTION
Fixes frozen enemies crashing the game because i forgot they existed in #343 ...
Tiny changes to the documentation as well to clear a false warning that was inside the FrozenEnemy file