### PR TITLE
lightworld save point+menu behavior

### DIFF
--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -365,8 +365,10 @@ function World:onKeyPressed(key)
             if Input.shift() then
                 save_pos = {self.player.x, self.player.y}
             end
-            if Game:isLight() or Game:getConfig("smallSaveMenu") then
+            if Game:getConfig("smallSaveMenu") then
                 self:openMenu(SimpleSaveMenu(Game.save_id, save_pos))
+            elseif Game:isLight() then
+                self:openMenu(LightSaveMenu(save_pos))
             else
                 self:openMenu(SaveMenu(save_pos))
             end

--- a/src/engine/game/world/events/savepoint.lua
+++ b/src/engine/game/world/events/savepoint.lua
@@ -74,4 +74,31 @@ function Savepoint:onTextEnd()
     end
 end
 
+function Savepoint:update()
+    super.update(self)
+
+    if Game:isLight() then
+        self.sprite.alpha = 0.5
+
+        if Game.world.player then
+            local dist = Utils.dist(self.x, self.y, Game.world.player.x, Game.world.player.y)
+
+
+            if dist <= 80 then
+                self.sprite.alpha = math.min(1, ((1 - (dist/80)) + 0.5))
+            end
+        end
+    end
+    
+end
+
+function Savepoint:getDebugInfo()
+    local info = super.getDebugInfo(self)
+    if Game:isLight() and Game.world.player then
+        table.insert(info, "Player Distance: " .. Utils.dist(self.x, self.y, Game.world.player.x, Game.world.player.y))
+        table.insert(info, "Alpha: " .. self.sprite.alpha)
+    end
+    return info
+end
+
 return Savepoint

--- a/src/engine/game/world/ui/lightsavemenu.lua
+++ b/src/engine/game/world/ui/lightsavemenu.lua
@@ -2,7 +2,7 @@
 ---@overload fun(...) : LightSaveMenu
 local LightSaveMenu, super = Class(Object)
 
-function LightSaveMenu:init(save_id, marker)
+function LightSaveMenu:init(marker)
     super.init(self, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT)
 
     self.parallax_x = 0
@@ -12,21 +12,57 @@ function LightSaveMenu:init(save_id, marker)
 
     self.font = Assets.getFont("main")
 
-    self.heart_sprite = Assets.getTexture("player/heart_menu")
+    self.ui_select = Assets.newSound("ui_select")
 
-    self.box = UIBox(140 - 8, 130 + 12, 359 + 17, 109 + 17)
-    self.box.layer = -1
-    self:addChild(self.box)
+    self.heart_sprite = Assets.getTexture("player/heart")
+    self.divider_sprite = Assets.getTexture("ui/box/dark/top")
+
+    self.main_box = UIBox(124, 130, 391, 154)
+    self.main_box.layer = -1
+    self:addChild(self.main_box)
+
+    self.save_box = Rectangle(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT)
+    self.save_box:setColor(0, 0, 0, 0.8)
+    self.save_box.layer = -1
+    self.save_box.visible = false
+    self:addChild(self.save_box)
+
+    self.save_header = UIBox(92, 44, 457, 42)
+    self.save_box:addChild(self.save_header)
+
+    self.save_list = UIBox(92, 156, 457, 258)
+    self.save_box:addChild(self.save_list)
+
+    self.overwrite_box = Rectangle(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT)
+    self.overwrite_box:setColor(0, 0, 0, 0.8)
+    self.overwrite_box.layer = 1
+    self.overwrite_box.visible = false
+    self:addChild(self.overwrite_box)
+
+    self.overwrite_box:addChild(UIBox(42, 132, 557, 217))
 
     self.marker = marker
 
-    -- MAIN, SAVED
+    -- MAIN, SAVE, SAVED, OVERWRITE, QUIT, QUITTING
     self.state = "MAIN"
 
     self.selected_x = 1
+    self.selected_y = 1
 
-    self.save_id = save_id or Game.save_id
-    self.saved_file = Kristal.getSaveFile(save_id)
+    self.saved_file = nil
+
+    self.saves = {}
+    for i = 1, 3 do
+        self.saves[i] = Kristal.getSaveFile(i)
+    end
+end
+
+function LightSaveMenu:updateSaveBoxSize()
+    if self.state == "SAVED" then
+        self.save_list.height = 210
+    else
+        self.save_list.height = 258
+    end
 end
 
 function LightSaveMenu:update()
@@ -36,25 +72,143 @@ function LightSaveMenu:update()
             Game.world:closeMenu()
         end
         if Input.pressed("left") or Input.pressed("right") then
+            self.selected_x = (self.selected_x == 1 and self.selected_y == 1) and 2 or 1
+        end
+        if Input.pressed("up") or Input.pressed("down") then
+            self.selected_y = self.selected_y == 1 and 2 or 1
+            self.selected_x = 1 -- Only one option on this row
+        end
+        if Input.pressed("confirm") then
+            if self.selected_x == 1 and self.selected_y == 1 then
+                self.state = "SAVE"
+
+                self.ui_select:stop()
+                self.ui_select:play()
+
+                self.selected_y = Game.save_id
+                self.saved_file = nil
+
+                self.main_box.visible = false
+                self.save_box.visible = true
+                self:updateSaveBoxSize()
+            elseif self.selected_x == 2 and self.selected_y == 1 then
+                self:remove()
+                Game.world:closeMenu()
+            elseif self.selected_x == 1 and self.selected_y == 2 then
+                self.state = "QUIT"
+
+                self.ui_select:stop()
+                self.ui_select:play()
+            end
+        end
+    elseif self.state == "SAVE" then
+        if Input.pressed("cancel") then
+            self.state = "MAIN"
+
+            self.ui_select:stop()
+            self.ui_select:play()
+
+            self.selected_x = 1
+            self.selected_y = 1
+
+            self.main_box.visible = true
+            self.save_box.visible = false
+        end
+        local last_selected = self.selected_y
+        if Input.pressed("up") then
+            self.selected_y = self.selected_y - 1
+        end
+        if Input.pressed("down") then
+            self.selected_y = self.selected_y + 1
+        end
+        self.selected_y = Utils.clamp(self.selected_y, 1, 4)
+        if Input.pressed("confirm") then
+            self.ui_select:stop()
+            self.ui_select:play()
+
+            if self.selected_y == 4 then
+                self.state = "MAIN"
+
+                self.selected_x = 1
+                self.selected_y = 1
+
+                self.main_box.visible = true
+                self.save_box.visible = false
+            elseif self.selected_y ~= Game.save_id and self.saves[self.selected_y] then
+                self.state = "OVERWRITE"
+
+                self.overwrite_box.visible = true
+            else
+                self.state = "SAVED"
+
+                self.saved_file = self.selected_y
+                Kristal.saveGame(self.saved_file, Game:save(self.marker))
+                self.saves[self.saved_file] = Kristal.getSaveFile(self.saved_file)
+
+                Assets.playSound("save")
+                self:updateSaveBoxSize()
+            end
+        end
+    elseif self.state == "SAVED" then
+        if Input.pressed("cancel") or Input.pressed("confirm") then
+            self:remove()
+            Game.world:closeMenu()
+        end
+    elseif self.state == "OVERWRITE" then
+        if Input.pressed("cancel") then
+            self.state = "SAVE"
+
+            self.selected_x = 1
+            self.overwrite_box.visible = false
+        end
+        if Input.pressed("left") or Input.pressed("right") then
             self.selected_x = self.selected_x == 1 and 2 or 1
         end
         if Input.pressed("confirm") then
             if self.selected_x == 1 then
                 self.state = "SAVED"
 
-                Kristal.saveGame(self.save_id, Game:save(self.marker))
-                self.saved_file = Kristal.getSaveFile(self.save_id)
+                self.saved_file = self.selected_y
+                Kristal.saveGame(self.saved_file, Game:save(self.marker))
+                self.saves[self.saved_file] = Kristal.getSaveFile(self.saved_file)
 
                 Assets.playSound("save")
-            elseif self.selected_x == 2 then
-                self:remove()
-                Game.world:closeMenu()
+
+                self.selected_x = 1
+                self.overwrite_box.visible = false
+                self:updateSaveBoxSize()
+            else
+                self.state = "SAVE"
+
+                self.selected_x = 1
+                self.overwrite_box.visible = false
             end
         end
-    elseif self.state == "SAVED" then
-        if Input.pressed("confirm") or Input.pressed("cancel") then
-            self:remove()
-            Game.world:closeMenu()
+    elseif self.state == "QUIT" then
+        if Input.pressed("left") or Input.pressed("right") then
+            self.selected_x = self.selected_x == 1 and 2 or 1
+        end
+        if Input.pressed("cancel") then
+            self.state = "MAIN"
+
+            self.selected_x = 1
+            self.selected_y = 2
+        end
+        if Input.pressed("confirm") then
+            if self.selected_x == 1 then
+                self.state = "QUITTING"
+
+                self.ui_select:stop()
+                self.ui_select:play()
+
+                Game:returnToMenu()
+
+            elseif self.selected_x == 2 then
+                self.state = "MAIN"
+
+                self.selected_x = 1
+                self.selected_y = 2
+            end
         end
     end
 
@@ -62,44 +216,179 @@ function LightSaveMenu:update()
 end
 
 function LightSaveMenu:draw()
+
+    local heart_positions_x = {142, 322}
+    local heart_positions_y = {228, 270}
+
     love.graphics.setFont(self.font)
-
-    if self.state == "SAVED" then
-        Draw.setColor(PALETTE["world_text_selected"])
-    else
-        Draw.setColor(PALETTE["world_text"])
-    end
-
-    local data      = self.saved_file or {}
-    local name      = data.name      or "Kris"
-    local level     = data.level     or 1
-    local playtime  = data.playtime  or 0
-    local room_name = data.room_name or ""
-
-    love.graphics.print(name,         self.box.x + 8,        self.box.y - 10 + 8)
-    love.graphics.print("LV "..level, self.box.x + 210 - 34, self.box.y - 10 + 8)
-
-    -- I don't think UNDERTALE displays hours, so let's only do minutes and seconds
-    local minutes = math.floor(playtime / 60)
-    local seconds = math.floor(playtime % 60)
-    local time_text = string.format("%d:%02d", minutes, seconds)
-    love.graphics.printf(time_text, self.box.x - 280 + 148, self.box.y - 10 + 8, 500, "right")
-
-    love.graphics.print(room_name, self.box.x + 8, self.box.y + 38)
-
     if self.state == "MAIN" then
-        love.graphics.print("Save",   self.box.x + 30  + 8, self.box.y + 98)
-        love.graphics.print("Return", self.box.x + 210 + 8, self.box.y + 98)
+        local data = Game:getSavePreview()
 
+        -- Header
+        Draw.setColor(PALETTE["world_text"])
+        love.graphics.print(data.name, 120, 120)
+        love.graphics.print("LV "..data.level, 352, 120)
+
+        local hours = math.floor(data.playtime / 3600)
+        local minutes = math.floor(data.playtime / 60 % 60)
+        local seconds = math.floor(data.playtime % 60)
+        local time_text = string.format("%d:%02d:%02d", hours, minutes, seconds)
+        love.graphics.print(time_text, 522 - self.font:getWidth(time_text), 120)
+
+        -- Room name
+        love.graphics.print(data.room_name, 319.5 - self.font:getWidth(data.room_name)/2, 170)
+
+        -- Buttons
+        love.graphics.print("Save", 170, 220)
+        love.graphics.print("Return", 350, 220)
+        love.graphics.print("Return to Title", 170, 260)
+
+        -- Heart
         Draw.setColor(Game:getSoulColor())
-        Draw.draw(self.heart_sprite, self.box.x + 10 + (self.selected_x - 1) * 180, self.box.y + 96 + 8, 0, 2, 2)
-    elseif self.state == "SAVED" then
-        love.graphics.print("File saved.", self.box.x + 30 + 8, self.box.y + 98)
-    end
+        Draw.draw(self.heart_sprite, heart_positions_x[self.selected_x], heart_positions_y[self.selected_y])
+    elseif self.state == "SAVE" or self.state == "OVERWRITE" then
+        self:drawSaveFile(0, Game:getSavePreview(), 74, 26, false, true)
 
-    Draw.setColor(1, 1, 1)
+        self:drawSaveFile(1, self.saves[1], 74, 138, self.selected_y == 1)
+        Draw.draw(self.divider_sprite, 74, 208, 0, 493, 2)
+
+        self:drawSaveFile(2, self.saves[2], 74, 222, self.selected_y == 2)
+        Draw.draw(self.divider_sprite, 74, 292, 0, 493, 2)
+
+        self:drawSaveFile(3, self.saves[3], 74, 306, self.selected_y == 3)
+        Draw.draw(self.divider_sprite, 74, 376, 0, 493, 2)
+
+        if self.selected_y == 4 then
+            Draw.setColor(Game:getSoulColor())
+            Draw.draw(self.heart_sprite, 236, 402)
+
+            Draw.setColor(PALETTE["world_text_selected"])
+        else
+            Draw.setColor(PALETTE["world_text"])
+        end
+        love.graphics.print("Return", 278, 394)
+    elseif self.state == "SAVED" then
+        self:drawSaveFile(self.saved_file, self.saves[self.saved_file], 74, 26, false, true)
+
+        self:drawSaveFile(1, self.saves[1], 74, 138, self.selected_y == 1)
+        Draw.draw(self.divider_sprite, 74, 208, 0, 493, 2)
+
+        self:drawSaveFile(2, self.saves[2], 74, 222, self.selected_y == 2)
+        Draw.draw(self.divider_sprite, 74, 292, 0, 493, 2)
+
+        self:drawSaveFile(3, self.saves[3], 74, 306, self.selected_y == 3)
+    elseif self.state == "QUIT" or self.state == "QUITTING" then
+
+        -- Prompt
+        love.graphics.print("Really return to title?", 170, 130)
+
+        -- Buttons
+        love.graphics.print("Yes", 170, 260)
+        love.graphics.print("No", 350, 260)
+
+        if self.state == "QUIT" then
+            -- Heart
+            Draw.setColor(Game:getSoulColor())
+            Draw.draw(self.heart_sprite, heart_positions_x[self.selected_x], heart_positions_y[2])
+        end
+    end
 
     super.draw(self)
+
+    if self.state == "OVERWRITE" then
+        Draw.setColor(PALETTE["world_text"])
+        local overwrite_text = "Overwrite Slot "..self.selected_y.."?"
+        love.graphics.print(overwrite_text, SCREEN_WIDTH/2 - self.font:getWidth(overwrite_text)/2, 123)
+
+        local function drawOverwriteSave(data, x, y)
+            local w = 478
+
+            -- Header
+            love.graphics.print(data.name, x + (w/2) - self.font:getWidth(data.name)/2, y)
+            love.graphics.print("LV "..data.level, x, y)
+
+            local hours = math.floor(data.playtime / 3600)
+            local minutes = math.floor(data.playtime / 60 % 60)
+            local seconds = math.floor(data.playtime % 60)
+            local time_text = string.format("%d:%02d:%02d", hours, minutes, seconds)
+            love.graphics.print(time_text, x + w - self.font:getWidth(time_text), y)
+
+            -- Room name
+            love.graphics.print(data.room_name, x + (w/2) - self.font:getWidth(data.room_name)/2, y+30)
+        end
+
+        Draw.setColor(PALETTE["world_text"])
+        drawOverwriteSave(self.saves[self.selected_y], 80, 165)
+        Draw.setColor(PALETTE["world_text_selected"])
+        drawOverwriteSave(Game:getSavePreview(), 80, 235)
+
+        if self.selected_x == 1 then
+            Draw.setColor(Game:getSoulColor())
+            Draw.draw(self.heart_sprite, 142, 332)
+
+            Draw.setColor(PALETTE["world_text_selected"])
+        else
+            Draw.setColor(PALETTE["world_text"])
+        end
+        love.graphics.print("Save", 170, 324)
+
+        if self.selected_x == 2 then
+            Draw.setColor(Game:getSoulColor())
+            Draw.draw(self.heart_sprite, 322, 332)
+
+            Draw.setColor(PALETTE["world_text_selected"])
+        else
+            Draw.setColor(PALETTE["world_text"])
+        end
+        love.graphics.print("Return", 350, 324)
+    end
+end
+
+function LightSaveMenu:drawSaveFile(index, data, x, y, selected, header)
+    if self.saved_file then
+        if self.saved_file == index then
+            Draw.setColor(PALETTE["world_text_selected"])
+        else
+            Draw.setColor(PALETTE["world_save_other"])
+        end
+    else
+        if selected then
+            Draw.setColor(PALETTE["world_text_selected"])
+        else
+            Draw.setColor(PALETTE["world_text"])
+        end
+    end
+    if self.saved_file == index and not header then
+        love.graphics.print("File Saved", x + 180, y + 22)
+    elseif not data then
+        love.graphics.print("New File", x + 193, y + 22)
+        if selected then
+            Draw.setColor(Game:getSoulColor())
+            Draw.draw(self.heart_sprite, x + 161, y + 30)
+        end
+    else
+        if self.saved_file or header then
+            love.graphics.print("LV "..data.level, x + 26, y + 6)
+        else
+            love.graphics.print("LV "..data.level, x + 50, y + 6)
+        end
+
+        love.graphics.print(data.name, x + (493 / 2) - self.font:getWidth(data.name) / 2, y + 6)
+
+        local hours = math.floor(data.playtime / 3600)
+        local minutes = math.floor(data.playtime / 60 % 60)
+        local seconds = math.floor(data.playtime % 60)
+        local time_text = string.format("%d:%02d:%02d", hours, minutes, seconds)
+        love.graphics.print(time_text, x + 467 - self.font:getWidth(time_text), y + 6)
+
+        love.graphics.print(data.room_name, x + (493 / 2) - self.font:getWidth(data.room_name) / 2, y + 38)
+
+        if selected and not header then
+            Draw.setColor(Game:getSoulColor())
+            Draw.draw(self.heart_sprite, x + 18, y + 14)
+        end
+    end
+    Draw.setColor(1, 1, 1)
 end
 
 return LightSaveMenu


### PR DESCRIPTION
Made the following changes to save points in the Light World, based on Chapter 4:
- Save points will be partially transparent until approached
- The light save menu is now nearly identical to the dark one, only with storage and recruits removed. In its place is a "Return to Title" option

Unrelated to chapter 4, fixed a bug where playtime for saves did not show hours on the save list.