### PR TITLE
attack effect overrides for weapons

### DIFF
--- a/data_templates/items/template.lua
+++ b/data_templates/items/template.lua
@@ -41,6 +41,13 @@ function item:init()
     self.bonus_name = nil
     self.bonus_icon = nil
 
+    -- Effect shown above enemy after attacking it with this item
+    self.attack_sprite = nil
+    -- Sound played when attacking
+    self.attack_sound = nil
+    -- Pitch of the attack sound
+    self.attack_pitch = nil
+
     -- Equippable characters (default true for armors, false for weapons)
     self.can_equip = {}
 

--- a/mods/_testmod/scripts/data/items/wood_blade.lua
+++ b/mods/_testmod/scripts/data/items/wood_blade.lua
@@ -10,6 +10,13 @@ function item:init()
     self.bonus_name = "EPIC"
     self.bonus_icon = "ui/menu/icon/smile"
 
+    -- Effect shown above enemy after attacking with this item
+    self.attack_sprite = "misc/realistic_explosion"
+    -- Sound played when attacking
+    self.attack_sound = "badexplosion"
+    -- Pitch of the attack sound
+    self.attack_pitch = 1
+
     self.bonuses = {
         attack = 1
     }

--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -1082,8 +1082,10 @@ function Battle:processAction(action)
         return false
 
     elseif action.action == "ATTACK" or action.action == "AUTOATTACK" then
-        local src = Assets.stopAndPlaySound(battler.chara:getAttackSound() or "laz_c")
-        src:setPitch(battler.chara:getAttackPitch() or 1)
+        local attacksound = battler.chara:getWeapon():getAttackSound() or battler.chara:getAttackSound()
+        local attackpitch  = battler.chara:getWeapon():getAttackPitch() or battler.chara:getAttackPitch()
+        local src = Assets.stopAndPlaySound(attacksound or "laz_c")
+        src:setPitch(attackpitch or 1)
 
         self.actions_done_timer = 1.2
 
@@ -1125,7 +1127,8 @@ function Battle:processAction(action)
             if damage > 0 then
                 Game:giveTension(Utils.round(enemy:getAttackTension(action.points or 100)))
 
-                local dmg_sprite = Sprite(battler.chara:getAttackSprite() or "effects/attack/cut")
+                local attacksprite = battler.chara:getWeapon():getAttackSprite() or battler.chara:getAttackSprite()
+                local dmg_sprite = Sprite(attacksprite or "effects/attack/cut")
                 dmg_sprite:setOrigin(0.5, 0.5)
                 if crit then
                     dmg_sprite:setScale(2.5, 2.5)

--- a/src/engine/game/common/data/item.lua
+++ b/src/engine/game/common/data/item.lua
@@ -100,6 +100,13 @@ function Item:init()
     -- The color of the bonus icon, always orange in DELTARUNE
     self.bonus_color = PALETTE["world_ability_icon"]
 
+    -- Effect shown above enemy after attacking with this item
+    self.attack_sprite = nil
+    -- Sound played when attacking
+    self.attack_sound = nil
+    -- Pitch of the attack sound
+    self.attack_pitch = nil
+
     -- Equippable characters (default true for armors, false for weapons)
     self.can_equip = {}
 
@@ -279,6 +286,10 @@ function Item:isSellable() return self.can_sell end
 function Item:getStatBonuses() return self.bonuses end
 function Item:getBonusName() return self.bonus_name end
 function Item:getBonusIcon() return self.bonus_icon end
+
+function Item:getAttackSprite() return self.attack_sprite end
+function Item:getAttackSound() return self.attack_sound end
+function Item:getAttackPitch() return self.attack_pitch end
 
 function Item:getReactions() return self.reactions end
 


### PR DESCRIPTION
The `attack_sprite`, `_sound`, and `_pitch` variables can be used to give unique attack effects to weapons, which take priority over those of the party member using them.

There is a weapon in chapter 3 that could make use of this, although I haven't added it, and won't say what it is due to potential spoilers.