### PR TITLE
Make hotswapping kristal.lua less catastrophic

### DIFF
--- a/src/hotswapper.lua
+++ b/src/hotswapper.lua
@@ -65,7 +65,10 @@ function Hotswapper.scan()
             value.modified = Hotswapper.getLastModified(value.path)
             print("Attempting to hotswap " .. key)
             --print(value.path)
+
+            HOTSWAPPING = true
             local updated_module, error_text = Hotswapper.hotswap(key)
+            HOTSWAPPING = false
             if not updated_module then
                 print(error_text)
             end

--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -1,7 +1,9 @@
 ---@class Kristal
 local Kristal = {}
 
-if not HOTSWAPPING then
+if HOTSWAPPING then
+    Utils.copyInto(Kristal, _G.Kristal)
+else
     Kristal.Config = {}
     Kristal.Mods = require("src.engine.mods")
     Kristal.Overlay = require("src.engine.overlay")


### PR DESCRIPTION
You'll still need to close the game, but now it won't delete your config. In order for this to be possible, the HOTSWAPPING statevar had to be implemented (it wasn't set before). This time I'm not sending it to Dark Place on accident. I gotta stop doing that.