### PR TITLE
Don't spawn TIRED messages when `setTired` is used to set an EnemyBattler's initial TIRED state

### DIFF
--- a/mods/_testmod/scripts/battle/enemies/starwalker.lua
+++ b/mods/_testmod/scripts/battle/enemies/starwalker.lua
@@ -57,6 +57,9 @@ function Starwalker:init()
     }
 
     self.blue = false
+
+    self:setTired(true)
+    self:setTired(false)
 end
 
 function Starwalker:onTurnEnd()

--- a/src/engine/game/battle/enemybattler.lua
+++ b/src/engine/game/battle/enemybattler.lua
@@ -147,13 +147,16 @@ function EnemyBattler:setTired(bool)
     if self.tired then
         self.comment = "(Tired)"
         if not old_tired and Game:getConfig("tiredMessages") then
-            self:statusMessage("msg", "tired")
-            Assets.playSound("spellcast", 0.5, 0.9)
+            -- Check for self.parent so setting Tired state in init doesn't crash
+            if self.parent then
+                self:statusMessage("msg", "tired")
+                Assets.playSound("spellcast", 0.5, 0.9)
+            end 
         end
     else
         self.comment = ""
         if old_tired and Game:getConfig("awakeMessages") then
-            self:statusMessage("msg", "awake")
+            if self.parent then self:statusMessage("msg", "awake") end
         end
     end
 end


### PR DESCRIPTION
Catches a small issue where using `setTired()` during `EnemyBattler:init` would result in a crash in trying to create Chapter 3's TIRED message (which shouldn't show when the enemy starts TIRED anyway)