### PR TITLE
Fix sparing without an animation breaking battles

### DIFF
--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -1068,6 +1068,11 @@ function Battle:processAction(action)
     if action.action == "SPARE" then
         local worked = enemy:canSpare()
 
+        local text = enemy:getSpareText(battler, worked)
+        if text then
+            self:battleText(text)
+        end
+
         battler:setAnimation("battle/spare", function()
             enemy:onMercy(battler)
             if not worked then
@@ -1075,11 +1080,6 @@ function Battle:processAction(action)
             end
             self:finishAction(action)
         end)
-
-        local text = enemy:getSpareText(battler, worked)
-        if text then
-            self:battleText(text)
-        end
 
         return false
 


### PR DESCRIPTION
Light World Kris and Susie will no longer cause the fabric of battles to break entirely as they inanimately stare you down... (Or any party lacking spare animations)