### PR TITLE
Changes to standalone exporting

### DIFF
--- a/build.py
+++ b/build.py
@@ -11,6 +11,7 @@ from pe_tools.version_info import parse_version_info, VersionInfo
 ver_str = "0.1.0"
 windows_ver = "0, 1, 0, 0"
 file_description = "Leading Brand DELTARUNE-type Software"
+is_standalone = False # Set this to true if you are building Kristal as a standalone fangame
 
 # Contains code from https://github.com/avast/pe_tools/blob/master/pe_tools/peresed.py
 
@@ -138,12 +139,15 @@ ignorefiles = [
     ".github",
     ".git",
     ".vscode",
-    "mods",
     "docs",
     "lib",
     "build",
     "output"
 ]
+
+# Ignore mods folder if not building as a standalone fangame
+if is_standalone == False:
+    ignorefiles.append("mods")
 
 try:
     for file in os.listdir(kristal_path):

--- a/src/engine/menu/mainmenutitle.lua
+++ b/src/engine/menu/mainmenutitle.lua
@@ -71,12 +71,8 @@ function MainMenuTitle:onKeyPressed(key, is_repeat)
 				if MainMenu.mod_list:getSelectedMod() and MainMenu.mod_list:getSelectedMod().soulColor then
 					MainMenu.heart.color = MainMenu.mod_list:getSelectedMod().soulColor
 				end
-            elseif self.has_target_saves then
-                self.menu:setState("FILESELECT")
             else
-                if not Kristal.loadMod(TARGET_MOD, 1) then
-                    error("Failed to load mod: " .. TARGET_MOD)
-                end
+                self.menu:setState("FILESELECT")
             end
 
         elseif option == "modfolder" then


### PR DESCRIPTION
I made some changes to make exporting mods as standalone fangames easier!
Just add your mod into the "mods" folder in the root Kristal folder and set "is_standalone" in build.py to True.
Then when you run build.py, it will include the mods folder so Kristal can find your mod when running the build!
And also, pressing "Start game" now goes to the file select instead of just starting the game, it annoyed me that I couldn't set my name before playing.