### PR TITLE
fix preview scripts breaking when favoriting

### DIFF
--- a/src/engine/menu/mainmenumodlist.lua
+++ b/src/engine/menu/mainmenumodlist.lua
@@ -371,6 +371,7 @@ function MainMenuModList:buildModListFavorited()
             local chunk = love.filesystem.load(mod.preview_script_path)
             local success, result = pcall(chunk, mod.path)
             if success then
+                self.scripts[mod.id] = result
                 button.preview_script = result
 
                 if result.init then


### PR DESCRIPTION
when rebuilding the mod list upon (un)favoriting one, the scripts table is cleared, but never actually remade. This appears to cause some preview scripts to not run anything but their init function, but not all of them (testmod's somehow works just fine without this fix)