### PR TITLE
Revert "Allow getFilesRecursive to work with symlinks"

### DIFF
--- a/src/utils/utils.lua
+++ b/src/utils/utils.lua
@@ -478,7 +478,7 @@ function Utils.getFilesRecursive(dir, ext)
     local result = {}
 
     -- Get all files and folders within the specified directory
-    local paths = love.filesystem.getDirectoryItems(dir.."/.")
+    local paths = love.filesystem.getDirectoryItems(dir)
     for _,path in ipairs(paths) do
         local info = love.filesystem.getInfo(dir.."/"..path)
 


### PR DESCRIPTION
Unfortunately, despite testing from source, this causes fused builds crash.

Reverts KristalTeam/Kristal#383