### PR TITLE
Update gonerkeyboard.lua

### DIFF
--- a/src/engine/objects/gonerkeyboard.lua
+++ b/src/engine/objects/gonerkeyboard.lua
@@ -137,7 +137,7 @@ end
 
 function GonerKeyboard:undoCharacter()
     if Utils.len(self.text) > 0 then
-        self.text = Utils.sub(1, Utils.len(self.text) - 1)
+        self.text = Utils.sub(self.text, 1, Utils.len(self.text) - 1)
     end
 end
 


### PR DESCRIPTION
Fixes a bug caused by #396 where deleting characters with the goner keyboard was all sorts of broken.
- Strings with 1 or 2 characters would be set to "1"
- Strings with 3 or more characters were cleared entirely