### PR TITLE
healing visual accuracy + `sparkle_color` for `EnemyBattler:hurt()`

### DIFF
--- a/src/engine/game/battle/battler.lua
+++ b/src/engine/game/battle/battler.lua
@@ -152,6 +152,15 @@ function Battler:sparkle(r, g, b)
     end, 4)
 end
 
+--- Creates a standard "healing effect" (flash, sparkles).
+---@param r? number
+---@param g? number
+---@param b? number
+function Battler:healEffect(r, g, b)
+    self:flash()
+    self:sparkle(r, g, b)
+end
+
 --- Creates a status text on the battler. \
 --- Used for information such as damage numbers, being downed, or missing a hit
 ---@param x?        number  The x-coordinate the message should appear at, relative to the battler.
@@ -166,8 +175,9 @@ end
 ---|"msg"       # The path to the sprite, relative to `ui/battle/message`, to use
 ---@param color?    table   The color used to draw the status message, defaulting to white
 ---@param kill?     boolean Whether this status should cause all other statuses to disappear.
+---@param delay?    number  The number of frames before this message first appears
 ---@return DamageNumber
-function Battler:statusMessage(x, y, type, arg, color, kill)
+function Battler:statusMessage(x, y, type, arg, color, kill, delay)
     x, y = self:getRelativePos(x, y)
 
     local offset = 0
@@ -175,7 +185,7 @@ function Battler:statusMessage(x, y, type, arg, color, kill)
         offset = (self.hit_count * 20)
     end
 
-    local percent = DamageNumber(type, arg, x + 4, y + 20 - offset, color)
+    local percent = DamageNumber(type, arg, x + 4, y + 20 - offset, color, delay)
     if kill then
         percent.kill_others = true
     end

--- a/src/engine/game/battle/enemybattler.lua
+++ b/src/engine/game/battle/enemybattler.lua
@@ -889,21 +889,20 @@ function EnemyBattler:onDefeatFatal(damage, battler)
 end
 
 --- Heals the enemy by `amount` health
----@param amount number
-function EnemyBattler:heal(amount)
+---@param amount            number  The amount of health to restore
+---@param sparkle_color?    table   The color of the heal sparkles (defaults to the standard green) or false to not show sparkles
+function EnemyBattler:heal(amount, sparkle_color)
     Assets.stopAndPlaySound("power")
     self.health = self.health + amount
 
-    self:flash()
-
     if self.health >= self.max_health then
         self.health = self.max_health
-        self:statusMessage("msg", "max")
+        self:statusMessage("msg", "max", nil, nil, 8)
     else
-        self:statusMessage("heal", amount, {0, 1, 0})
+        self:statusMessage("heal", amount, {0, 1, 0}, nil, 8)
     end
 
-    self:sparkle()
+    self:healEffect(unpack(sparkle_color or {}))
 end
 
 --- Freezes this enemy and defeats them with the reason `"FROZEN"` \

--- a/src/engine/game/battle/partybattler.lua
+++ b/src/engine/game/battle/partybattler.lua
@@ -269,7 +269,7 @@ end
 
 --- Heals the Battler by `amount` health and does healing effects
 ---@param amount            number  The amount of health to restore
----@param sparkle_color?    table   The color of the heal sparkles (defaults to the standard green)
+---@param sparkle_color?    table   The color of the heal sparkles (defaults to the standard green) or false to not show sparkles
 ---@param show_up?          boolean Whether the "UP" status message should show if the battler is revived by the heal
 function PartyBattler:heal(amount, sparkle_color, show_up)
     Assets.stopAndPlaySound("power")
@@ -281,22 +281,20 @@ function PartyBattler:heal(amount, sparkle_color, show_up)
     local was_down = self.is_down
     self:checkHealth()
 
-    self:flash()
-
     if self.chara:getHealth() >= self.chara:getStat("health") then
         self.chara:setHealth(self.chara:getStat("health"))
-        self:statusMessage("msg", "max")
+        self:statusMessage("msg", "max", nil, nil, 8)
     else
-        if show_up then
-            if was_down ~= self.is_down then
-                self:statusMessage("msg", "up")
-            end
+        if show_up and was_down ~= self.is_down then
+            self:statusMessage("msg", "up", nil, nil, 1)
         else
-            self:statusMessage("heal", amount, {0, 1, 0})
+            self:statusMessage("heal", amount, {0, 1, 0}, nil, show_up and 1 or 8)
         end
     end
-
-    self:sparkle(unpack(sparkle_color or {}))
+    
+    if not show_up then
+        self:healEffect(unpack(sparkle_color or {}))
+    end
 end
 
 --- Checks whether the battler's down state needs to be changed based on its current health

--- a/src/engine/game/effects/damagenumber.lua
+++ b/src/engine/game/effects/damagenumber.lua
@@ -7,7 +7,7 @@ local DamageNumber, super = Class(Object)
 --    "mercy"/"damage": amount
 --    "msg": message sprite name ("down", "frozen", "lost", "max", "mercy", "miss", "recruit", "up", "tired", and "awake")
 
-function DamageNumber:init(type, arg, x, y, color)
+function DamageNumber:init(type, arg, x, y, color, delay)
     super.init(self, x, y)
 
     self:setOrigin(1, 0)
@@ -20,7 +20,7 @@ function DamageNumber:init(type, arg, x, y, color)
     self:setDisplay(type, arg, true)
 
     self.timer = 0
-    self.delay = 2
+    self.delay = delay or 2
     self.kill_delay = 0
 
     self.bounces = 0


### PR DESCRIPTION
Corrects two visual inaccuracies with Kristal's heal effects:
- Delay before heal text being 2 frames, rather than DELTARUNE's 8 frames (except auto-heals from DOWNed, which are 1 frame)
- auto-heals from DOWNed not showing heal numbers and also showing other heal effects (sparkles) that shouldn't be present

Also adds `sparkle_color` to `EnemyBattler:hurt()` for no reason other than consistency with `PartyBattler`'s equivalent (which seems to solely be there for modder use as well)