### PR TITLE
move `FlashFade` logic to `draw`

### DIFF
--- a/src/engine/game/effects/flashfade.lua
+++ b/src/engine/game/effects/flashfade.lua
@@ -9,6 +9,8 @@ function FlashFade:init(texture, x, y)
     self.siner = 0
     self.target = nil
 
+    self.alpha = 0
+
     self.color_mask = self:addFX(ColorMaskFX())
 end
 


### PR DESCRIPTION
This should fix the occasional strange flicker effect that can happen when creating `FlashFade`s (most noticable when healing in battle)