### PR TITLE
File loading is now managed by coroutines. Add fallbacks if FFI doesn't work. Ensure project syntax uses Lua 5.1. Fixed an error when spamming "reload".

### DIFF
--- a/conf.lua
+++ b/conf.lua
@@ -15,7 +15,7 @@ function love.conf(t)
     t.identity = "kristal"
     -- TODO: hmm
     t.version = "11.0"
-    t.console = true
+    -- t.console = true
     t.window.title = "Kristal"
     t.window.icon = "icon.png"
     t.window.width = 640

--- a/conf.lua
+++ b/conf.lua
@@ -15,7 +15,7 @@ function love.conf(t)
     t.identity = "kristal"
     -- TODO: hmm
     t.version = "11.0"
-
+    t.console = true
     t.window.title = "Kristal"
     t.window.icon = "icon.png"
     t.window.width = 640

--- a/luadoc_meta/.buildDocs.lua
+++ b/luadoc_meta/.buildDocs.lua
@@ -15,8 +15,8 @@ export.makeDocObject['variable'] = function(source, obj, has_seen)
     if (obj.type == 'variable') then
         for i,pair in pairs(source:getSets(ws.rootUri)) do
             if(pair.type ~= 'setglobal') then
-                goto CONTINUE
-            end
+            -- continue
+            else
             --print(obj.name, i)
             obj.defines[i].value = '???'
             if(SIMPLE_TYPES[pair.value.type]) then
@@ -40,8 +40,8 @@ export.makeDocObject['variable'] = function(source, obj, has_seen)
             elseif(pair.value.type == 'function') then
                 obj.defines[i].value = 'idk lol is function'
             end
-           --print()
-            ::CONTINUE::
+        --print()
+        end
         end
     end
     

--- a/main.lua
+++ b/main.lua
@@ -33,6 +33,7 @@ Kristal = require("src.kristal")
 Game = Kristal.States["Game"]
 MainMenu = Kristal.States["MainMenu"]
 
+LoaderProcedure = require("src.engine.loadthread")
 Assets = require("src.engine.assets")
 Music = require("src.engine.music")
 Input = require("src.engine.input")

--- a/src/engine/assets.lua
+++ b/src/engine/assets.lua
@@ -60,6 +60,11 @@ end
 
 ---@param data Assets.data
 function Assets.loadData(data)
+    
+    -- print("The data has been loaded and is being inserted")
+    -- for iv, k in pairs(data.texture) do
+    --     print("An entry of it is:", iv, k)
+    -- end
     Utils.merge(self.data, data, true)
 
     self.parseData(data)

--- a/src/engine/game/debugsystem.lua
+++ b/src/engine/game/debugsystem.lua
@@ -818,11 +818,20 @@ function DebugSystem:registerDefaults()
                             Hotswapper.scan(); self:refresh()
                         end)
     self:registerOption("main", "Reload", "Reload the mod. Hold shift to\nnot temporarily save.", function ()
+        local cur_state = Kristal.getState()
+        -- print("The game state is", cur_state)
+
+        
         if Kristal.getModOption("hardReset") then
             love.event.quit("restart")
         else
             if Mod then
-                Kristal.quickReload(Input.shift() and "save" or "temp")
+                if cur_state.loading == true or next(cur_state) == nil then
+                    -- print("Spamming the reload button?")
+                else
+                    Kristal.quickReload(Input.shift() and "save" or "temp")
+                end
+                
             else
                 Kristal.returnToMenu()
             end

--- a/src/engine/game/world/tileset.lua
+++ b/src/engine/game/world/tileset.lua
@@ -63,10 +63,25 @@ function Tileset:init(data, path, base_dir)
         self.id_count = math.max(self.id_count, tile.id + 1)
     end
 
+
+    -- local function key_getter(tbl)
+    --     local result = {}
+    --     for k in pairs(tbl) do
+    --         table.insert(result, k)
+    --     end
+    --     return result
+    -- end
+
+
+
     if data.image then
         local image_path = Utils.absoluteToLocalPath("assets/sprites/", data.image, self.base_dir)
         self.texture = Assets.getTexture(image_path)
         if not self.texture then
+            -- print(key_getter(Assets.data.texture))
+            -- for iv, k in pairs(Assets.data.texture) do
+            --     print("This key is", iv, k)
+            -- end
             error("Could not load tileset texture: " .. tostring(image_path) .. " [" .. tostring(path) .. "]")
         end
     end

--- a/src/engine/loadstate.lua
+++ b/src/engine/loadstate.lua
@@ -44,21 +44,46 @@ function Loading:enter(from, dir)
     self.done_loading = false
 end
 
+
+
 function Loading:beginLoad()
     Kristal.clearAssets(true)
 
     self.loading = true
     self.load_complete = false
 
-    Kristal.loadAssets("", "all", "")
-    Kristal.loadAssets("", "mods", "", function ()
-        self.loading = false
-        self.load_complete = true
+    local function asset_loader()
 
-        Assets.saveData()
+        local all_complete = false
+        local mods_complete = false
 
-        Kristal.setDesiredWindowTitleAndIcon()
-    end)
+        local function break_me_out() 
+            if all_complete and mods_complete then
+                self.loading = false
+                self.load_complete = true
+                Assets.saveData()
+                Kristal.setDesiredWindowTitleAndIcon()
+            end
+        end
+
+        Kristal.loadAssets("", "all", "", function () 
+            all_complete = true
+            break_me_out()
+        end)
+        Kristal.loadAssets("", "mods", "", function ()
+            mods_complete = true
+            break_me_out()
+            -- self.loading = false
+            -- print("The loading of the mods are complete")
+            -- self.load_complete = true
+            -- Assets.saveData()
+            -- Kristal.setDesiredWindowTitleAndIcon()
+        end)
+    end
+
+    asset_loader()
+
+
 end
 
 function Loading:update()

--- a/src/engine/menu/mainmenucontrols.lua
+++ b/src/engine/menu/mainmenucontrols.lua
@@ -75,8 +75,8 @@ function MainMenuControls:registerModPages()
         local page = {}
         local mod = Kristal.Mods.getMod(mod_id)
         if mod["hideKeybinds"] then
-            goto continue
-        end
+            -- goto continue
+        else
 
         page.title = tostring(mod.name):upper()
         page.mod = mod_id
@@ -87,7 +87,7 @@ function MainMenuControls:registerModPages()
         end
 
         table.insert(self.pages, page)
-        ::continue::
+        end
     end
 end
 

--- a/src/engine/overlay.lua
+++ b/src/engine/overlay.lua
@@ -110,9 +110,9 @@ function Overlay:draw()
     love.graphics.pop()
 
     -- Draw the loader messages
-    if Kristal.Loader.message ~= "" then
+    if Kristal.loader_message ~= "" then
         love.graphics.setFont(self.font)
-        local text = Kristal.Loader.message
+        local text = Kristal.loader_message
         local x = SCREEN_WIDTH - self.font:getWidth(text) - 2
         local y = SCREEN_HEIGHT - self.font:getHeight() - 4
         Draw.setColor(0, 0, 0)

--- a/src/engine/ui/component.lua
+++ b/src/engine/ui/component.lua
@@ -299,7 +299,9 @@ function Component:getInnerWidth()
 
     local width = 0
     for _, child in ipairs(self:getComponents()) do
-        if child.x_sizing and child.x_sizing:includes(FillSizing) then goto continue end
+        if child.x_sizing and child.x_sizing:includes(FillSizing) then 
+            -- goto continue 
+        else
         local x = (child.x + self.scroll_x) - self.padding[1] - (child.margins and child.margins[1] or 0)
         local child_width, _ = child:getScaledSize()
         if (child.getTotalSize) then child_width, _ = child:getTotalSize() end
@@ -307,7 +309,7 @@ function Component:getInnerWidth()
         if child_width > width then
             width = child_width
         end
-        ::continue::
+        end
     end
     return width
 end
@@ -319,7 +321,9 @@ function Component:getInnerHeight()
 
     local height = 0
     for _, child in ipairs(self:getComponents()) do
-        if child.y_sizing and child.y_sizing:includes(FillSizing) then goto continue end
+        if child.y_sizing and child.y_sizing:includes(FillSizing) then 
+            -- goto continue  
+        else
         local y = (child.y + self.scroll_y) - self.padding[2] - (child.margins and child.margins[2] or 0)
         local _, child_height = child:getScaledSize()
         if (child.getTotalSize) then _, child_height = child:getTotalSize() end
@@ -327,7 +331,7 @@ function Component:getInnerHeight()
         if child_height > height then
             height = child_height
         end
-        ::continue::
+        end
     end
     return height
 end

--- a/src/engine/ui/sizing/fit.lua
+++ b/src/engine/ui/sizing/fit.lua
@@ -11,7 +11,9 @@ end
 function FitSizing:getWidth()
     local width = 0
     for _, child in ipairs(self:getComponents()) do
-        if child.x_sizing and child.x_sizing:includes(FillSizing) then goto continue end
+        if child.x_sizing and child.x_sizing:includes(FillSizing) then 
+            -- goto continue 
+        else
         local x = child.x - ({self.parent:getScaledPadding()})[1] - (child.margins and ({child:getScaledMargins()})[1] or 0)
         local child_width, _ = child:getScaledSize()
         if (child.getTotalSize) then child_width, _ = child:getTotalSize() end
@@ -19,7 +21,7 @@ function FitSizing:getWidth()
         if child_width > width then
             width = child_width
         end
-        ::continue::
+        end
     end
     return width + ({self.parent:getScaledPadding()})[1] + ({self.parent:getScaledPadding()})[3]
 end
@@ -28,7 +30,9 @@ end
 function FitSizing:getHeight()
     local height = 0
     for _, child in ipairs(self:getComponents()) do
-        if child.y_sizing and child.y_sizing:includes(FillSizing) then goto continue end
+        if child.y_sizing and child.y_sizing:includes(FillSizing) then 
+            -- goto continue 
+        else
         local y = child.y - ({self.parent:getScaledPadding()})[2] - (child.margins and ({child:getScaledMargins()})[2] or 0)
         local _, child_height = child:getScaledSize()
         if (child.getTotalSize) then _, child_height = child:getTotalSize() end
@@ -36,7 +40,7 @@ function FitSizing:getHeight()
         if child_height > height then
             height = child_height
         end
-        ::continue::
+        end
     end
     return height + ({self.parent:getScaledPadding()})[2] + ({self.parent:getScaledPadding()})[4]
 end

--- a/src/hotswapper.lua
+++ b/src/hotswapper.lua
@@ -13,6 +13,7 @@ Hotswapper.files = {
 package.path = package.path..";"..love.filesystem.getSource().."/?.lua"
 
 function Hotswapper.updateFiles(file_type)
+    if package.searchpath == nil then return end
     if not enabled then return end
     if file_type == "required" then
         print("Updating file information for required packages...")

--- a/src/lib/discordrpc.lua
+++ b/src/lib/discordrpc.lua
@@ -1,4 +1,10 @@
-local ffi = require "ffi"
+-- local ffi = require "ffi"
+local success, ffi = pcall(require, "ffi")
+
+DISCORD_RPC_AVAILABLE = false
+if not success then
+    return
+end
 
 local name = "discord-rpc"
 

--- a/src/lib/https.lua
+++ b/src/lib/https.lua
@@ -1,4 +1,9 @@
-local ffi = require "ffi"
+-- local ffi = require "ffi"
+local success, ffi = pcall(require, "ffi")
+if not success then 
+    HTTPS_AVAILABLE = false
+    return
+end
 
 local name = "https.so"
 


### PR DESCRIPTION
Three changes in one!

While this change should not have any noticeable changes in terms of the API visible to modders, the change is sort of heavy since it rewrites the entire logic used to load files - though this only impacts methods that are already well-encapsulated.

## File loading changes

Loading new files used to be done on a separate physical thread. This has been changed to be managed by a coroutine that yields very frequently. **The performance impact is minimal** and the game does not freeze.

This ensures the engine can run in the event multithreading cannot work. Note that HTTPS is still run on a separate thread. Technically, it makes sense to make HTTPS into a coroutine, however, it's not needed. If multithreading can't work here, the module won't run.

## FFI doesn't work -> catch it

Modules requiring FFI, when it can't load FFI, no longer render the engine unplayable effectively by disabling it and wrapping the logic that loads FFI in a pcall

## Ensure project uses 5.1 compatible syntax

Removed all `goto` statements. Bitwise AND is now bundled rather than assumed to have been packaged with lua.

## Fixed an error when "Reload" button is spammed

The reload button and CTRL+R will not do anything if the game's state is loading or blank.

## Demo

This version can successfully compile to love.js and is accessible [HERE](https://i-winxd.github.io/kristal-wasm-compiler/).

*NOTE: debug > reload* crashes on the web port but works fine otherwise.



