### PR TITLE
"TIRED" and "AWAKE" will no longer display if the enemy was defeated

### DIFF
--- a/src/engine/game/battle/enemybattler.lua
+++ b/src/engine/game/battle/enemybattler.lua
@@ -161,7 +161,7 @@ function EnemyBattler:setTired(bool)
     self.tired = bool
     if self.tired then
         self.comment = "(Tired)"
-        if not old_tired and Game:getConfig("tiredMessages") then
+        if not old_tired and Game:getConfig("tiredMessages") and self.health > 0 then
             -- Check for self.parent so setting Tired state in init doesn't crash
             if self.parent then
                 self:statusMessage("msg", "tired")
@@ -170,7 +170,7 @@ function EnemyBattler:setTired(bool)
         end
     else
         self.comment = ""
-        if old_tired and Game:getConfig("awakeMessages") then
+        if old_tired and Game:getConfig("awakeMessages") and self.health > 0 then
             if self.parent then self:statusMessage("msg", "awake") end
         end
     end


### PR DESCRIPTION
Will now only appear if the enemy has more than 0 health.
To fix an issue where it would display even if tired percentage is 0 or if the enemy was defeated in 1 hit before it appeared.