### PR TITLE
Implemented fixed Rude Buster damage calculation & new Chapter 3+ effect

### DIFF
--- a/configs/chapter1.json
+++ b/configs/chapter1.json
@@ -15,6 +15,7 @@
     "oldTensionBar": true,           // Syle of TP bar
     "oldUIPositions": true,          // Old positions of various UI elements
     "oldGameOver": true,             // The game over screen used in chapter 1
+    "oldRudeBuster": true,           // Old Rude Buster damage calculation and effect
 
     "speechBubble": "round",         // Default enemy speech bubble style
 

--- a/configs/chapter2.json
+++ b/configs/chapter2.json
@@ -15,6 +15,7 @@
     "oldTensionBar": false,          // Syle of TP bar
     "oldUIPositions": false,         // Old positions of various UI elements
     "oldGameOver": false,            // The game over screen used in chapter 1
+    "oldRudeBuster": true,           // Old Rude Buster damage calculation and effect
 
     "speechBubble": "cyber",         // Default enemy speech bubble style
 

--- a/configs/chapter3.json
+++ b/configs/chapter3.json
@@ -15,6 +15,7 @@
     "oldTensionBar": false,          // Syle of TP bar
     "oldUIPositions": false,         // Old positions of various UI elements
     "oldGameOver": false,            // The game over screen used in chapter 1
+    "oldRudeBuster": false,          // Old Rude Buster damage calculation and effect
 
     "speechBubble": "cyber",         // Default enemy speech bubble style
 

--- a/configs/chapter4.json
+++ b/configs/chapter4.json
@@ -15,6 +15,7 @@
     "oldTensionBar": false,          // Syle of TP bar
     "oldUIPositions": false,         // Old positions of various UI elements
     "oldGameOver": false,            // The game over screen used in chapter 1
+    "oldRudeBuster": false,          // Old Rude Buster damage calculation and effect
 
     "speechBubble": "cyber",         // Default enemy speech bubble style
 

--- a/data/spells/red_buster.lua
+++ b/data/spells/red_buster.lua
@@ -48,9 +48,9 @@ function spell:onCast(user, target)
         Assets.playSound("rudebuster_swing")
         local x, y = user:getRelativePos(user.width, user.height/2 - 10, Game.battle)
         local tx, ty = target:getRelativePos(target.width/2, target.height/2, Game.battle)
-        local blast = RudeBusterBeam(true, x, y, tx, ty, function(pressed)
-            local damage = self:getDamage(user, target, pressed)
-            if pressed then
+        local blast = RudeBusterBeam(true, x, y, tx, ty, function(damage_bonus, play_sound)
+            local damage = self:getDamage(user, target, damage_bonus)
+            if play_sound then
                 Assets.playSound("scytheburst")
             end
             local flash = target:flash()
@@ -67,11 +67,8 @@ function spell:onCast(user, target)
     return false
 end
 
-function spell:getDamage(user, target, pressed)
-    local damage = math.ceil((user.chara:getStat("magic") * 6) + (user.chara:getStat("attack") * 13) - (target.defense * 6)) + 90
-    if pressed then
-        damage = damage + 30
-    end
+function spell:getDamage(user, target, damage_bonus)
+    local damage = math.ceil((user.chara:getStat("magic") * 6) + (user.chara:getStat("attack") * 13) - (target.defense * 6)) + 90 + damage_bonus
     return damage
 end
 

--- a/data/spells/rude_buster.lua
+++ b/data/spells/rude_buster.lua
@@ -56,9 +56,9 @@ function spell:onCast(user, target)
         Assets.playSound("rudebuster_swing")
         local x, y = user:getRelativePos(user.width, user.height/2 - 10, Game.battle)
         local tx, ty = target:getRelativePos(target.width/2, target.height/2, Game.battle)
-        local blast = RudeBusterBeam(false, x, y, tx, ty, function(pressed)
-            local damage = self:getDamage(user, target, pressed)
-            if pressed then
+        local blast = RudeBusterBeam(false, x, y, tx, ty, function(damage_bonus, play_sound)
+            local damage = self:getDamage(user, target, damage_bonus)
+            if play_sound then
                 Assets.playSound("scytheburst")
             end
             target:flash()
@@ -74,11 +74,8 @@ function spell:onCast(user, target)
     return false
 end
 
-function spell:getDamage(user, target, pressed)
-    local damage = math.ceil((user.chara:getStat("magic") * 5) + (user.chara:getStat("attack") * 11) - (target.defense * 3))
-    if pressed then
-        damage = damage + 30
-    end
+function spell:getDamage(user, target, damage_bonus)
+    local damage = math.ceil((user.chara:getStat("magic") * 5) + (user.chara:getStat("attack") * 11) - (target.defense * 3)) + damage_bonus
     return damage
 end
 

--- a/src/engine/game/effects/rudebusterbeam.lua
+++ b/src/engine/game/effects/rudebusterbeam.lua
@@ -25,6 +25,12 @@ function RudeBusterBeam:init(red, x, y, tx, ty, after)
 
     self.afterimg_timer = 0
     self.after_func = after
+
+    self.bolt_timer = 0
+    self.final_bolt = 0
+    self.final_bolt_set = false
+    self.chosen_bolt = 0
+    self.bonus_anim = false
 end
 
 function RudeBusterBeam:update()
@@ -33,17 +39,58 @@ function RudeBusterBeam:update()
     local dir = Utils.angle(self.x, self.y, self.target_x, self.target_y)
     self.rotation = self.rotation + (Utils.angleDiff(dir, self.rotation) / 4) * DTMULT
 
-    if Input.pressed("confirm") then
+    self.bolt_timer = self.bolt_timer + DTMULT
+    if Input.pressed("confirm") and not self.pressed then
         self.pressed = true
+        self.chosen_bolt = self.bolt_timer
     end
 
     if Utils.dist(self.x, self.y, self.target_x, self.target_y) <= 40 then
+        if not self.final_bolt_set then
+            self.final_bolt_set = true
+            self.final_bolt = self.bolt_timer
+        end
         if self.after_func then
-            self.after_func(self.pressed)
+            local damage_bonus, play_sound = 0, false
+            if not Game:getConfig("oldRudeBuster") then
+                -- Values are rounded since we have to account for different framerates
+                -- Don't use floor or ceil since frame rate occasionally drops on low end devices
+                -- Which will throw off the values
+                self.chosen_bolt = Utils.round(self.chosen_bolt)
+                self.final_bolt = Utils.round(self.final_bolt)
+                if self.chosen_bolt > 0 then
+                    if self.chosen_bolt == self.final_bolt then
+                        damage_bonus = 30
+                    elseif self.chosen_bolt == self.final_bolt - 1 then
+                        damage_bonus = 28
+                    elseif self.chosen_bolt == self.final_bolt - 2 then
+                        damage_bonus = 22
+                    elseif self.chosen_bolt == self.final_bolt - 3 then
+                        damage_bonus = 20
+                    elseif self.chosen_bolt == self.final_bolt - 4 then
+                        damage_bonus = 13
+                    elseif self.chosen_bolt == self.final_bolt - 5 then
+                        damage_bonus = 11
+                    elseif self.chosen_bolt == self.final_bolt - 6 then
+                        damage_bonus = 10
+                    end
+
+                    if math.abs(self.chosen_bolt - self.final_bolt) <= 2 then
+                        self.bonus_anim = true
+                        play_sound = true
+                    end
+                end
+            else
+                if self.pressed then
+                    damage_bonus = 30
+                    play_sound = true
+                end
+            end
+            self.after_func(damage_bonus, play_sound)
         end
         Assets.playSound("rudebuster_hit")
         for i = 1, 8 do
-            local burst = RudeBusterBurst(self.red, self.target_x, self.target_y, math.rad(45 + ((i - 1) * 90)), i > 4)
+            local burst = RudeBusterBurst(self.red, self.target_x, self.target_y, math.rad(45 + ((i - 1) * 90)), i > 4, self.bonus_anim and 40 or 25)
             burst.layer = self.layer + (0.01 * i)
             self.parent:addChild(burst)
         end

--- a/src/engine/game/effects/rudebusterburst.lua
+++ b/src/engine/game/effects/rudebusterburst.lua
@@ -2,7 +2,7 @@
 ---@overload fun(...) : RudeBusterBurst
 local RudeBusterBurst, super = Class(Sprite)
 
-function RudeBusterBurst:init(red, x, y, angle, slow)
+function RudeBusterBurst:init(red, x, y, angle, slow, speed)
     super.init(self, red and "effects/rudebuster/beam_red" or "effects/rudebuster/beam", x, y)
 
     self:setOrigin(0.5, 0.5)
@@ -12,7 +12,7 @@ function RudeBusterBurst:init(red, x, y, angle, slow)
     self:play(1/15, true)
 
     self.rotation = angle
-    self.physics.speed = 25
+    self.physics.speed = speed
     self.physics.match_rotation = true
 
     self.slow = slow

--- a/src/engine/menu/mainmenumodconfig.lua
+++ b/src/engine/menu/mainmenumodconfig.lua
@@ -214,6 +214,7 @@ function MainMenuModConfig:registerOptions()
     self:registerOption("oldTensionBar",          "Old Tension Bar",           "Whether the Tension Bar uses blocky corners or not.",                                "selection", {nil, true, false})
     self:registerOption("oldUIPositions",         "Old UI Positions",          "Whether to use Chapter 1 positions of UI elements or not.",                          "selection", {nil, true, false})
     self:registerOption("oldGameOver",            "Old Game Over",             "Whether to use Chapter 1 game over or not.",                                         "selection", {nil, true, false})
+    self:registerOption("oldRudeBuster",          "Old Rude Buster",           "Whether to use Chapter 1/2 Rude Buster damage calculation and effect.",              "selection", {nil, true, false})
     self:registerOption("targetSystem",           "Targeting System",          "Whether battles should use the targeting system or not",                             "selection", {nil, true, false})
     self:registerOption("soulInvBetweenWaves",    "Keep Soul Invulnerability", "Whether the soul invulnerability will carry between waves in battles",               "selection", {nil, true, false})
     self:registerOption("speechBubble",           "Speech Bubble Style",       "The default style for enemy speech bubbles",                                         "selection", {nil, "round", "cyber"}) -- unhardcode


### PR DESCRIPTION
Rude Buster and Red Buster damage calculation for Chapter 3+ has been implemented.
Additionally, Rude Buster in Chapter 3+ has a slight change where the beam particles upon impact travel farther if the player lands a near-perfect or perfect hit. This has also been added.
Both of those can be toggled with the config option `oldRudeBuster`