### PR TITLE
battle idle speed accuracy

### DIFF
--- a/data/actors/kris.lua
+++ b/data/actors/kris.lua
@@ -41,7 +41,7 @@ function actor:init()
         ["slide"]               = {"slide", 4/30, true},
 
         -- Battle animations
-        ["battle/idle"]         = {"battle/idle", 0.2, true},
+        ["battle/idle"]         = {"battle/idle", 1/6, true},
 
         ["battle/attack"]       = {"battle/attack", 1/15, false},
         ["battle/act"]          = {"battle/act", 1/15, false},

--- a/data/actors/noelle.lua
+++ b/data/actors/noelle.lua
@@ -38,7 +38,7 @@ function actor:init()
     -- Table of sprite animations
     self.animations = {
         -- Battle animations
-        ["battle/idle"]         = {"battle/idle", 0.2, true},
+        ["battle/idle"]         = {"battle/idle", 1/6, true},
 
         ["battle/attack"]       = {"battle/attack", 1/15, false},
         ["battle/act"]          = {"battle/act", 1/15, false},
@@ -68,7 +68,7 @@ function actor:init()
     -- Alternate animations to use for Noelle weird mode (false to disable the animation)
     self.animations_alt = {
         -- Battle animations
-        ["battle/idle"]         = {"battle_alt/idle", 0.2, true},
+        ["battle/idle"]         = {"battle_alt/idle", 1/6, true},
 
         ["battle/attack"]       = {"battle/spell", 1/15, false, next="battle/idle"},
 

--- a/data/actors/ralsei.lua
+++ b/data/actors/ralsei.lua
@@ -44,7 +44,7 @@ function actor:initChapter1()
     -- Table of sprite animations
     self.animations = {
         -- Battle animations
-        ["battle/idle"]         = {"battle/idle", 0.2, true},
+        ["battle/idle"]         = {"battle/idle", 1/6, true},
 
         ["battle/attack"]       = {"battle/attack", 1/15, false},
         ["battle/act"]          = {"battle/act", 1/15, false},
@@ -180,7 +180,7 @@ function actor:initChapter2()
         ["slide"]               = {"slide", 4/30, true},
 
         -- Battle animations
-        ["battle/idle"]         = {"battle/idle", 0.2, true},
+        ["battle/idle"]         = {"battle/idle", 1/6, true},
 
         ["battle/attack"]       = {"battle/attack", 1/15, false},
         ["battle/act"]          = {"battle/act", 1/15, false},

--- a/data/actors/susie.lua
+++ b/data/actors/susie.lua
@@ -51,7 +51,7 @@ function actor:init(style)
         ["slide"]               = {"slide", 4/30, true},
 
         -- Battle animations
-        ["battle/idle"]         = {"battle/idle", 0.2, true},
+        ["battle/idle"]         = {"battle/idle", 1/6, true},
 
         ["battle/attack"]       = {"battle/attack", 1/15, false},
         ["battle/act"]          = {"battle/act", 1/15, false},


### PR DESCRIPTION
Changes battle idle speeds for all characters from `1/5` to `1/6` to be fully accurate to DELTARUNE