### PR TITLE
In the dark transition in the test mod, the child will be added to Game.stage

### DIFF
--- a/mods/_testmod/scripts/world/cutscenes/enterdark.lua
+++ b/mods/_testmod/scripts/world/cutscenes/enterdark.lua
@@ -27,7 +27,7 @@ return function(cutscene)
     end
     transition.layer = 99999
 
-    Game.world:addChild(transition)
+    Game.stage:addChild(transition)
 
     local waiting = true
     local endData = nil


### PR DESCRIPTION
The reason for this change is because when you load certain maps, it will display certain tilesets for a frame or two if the transition is added to the world instead of to the stage.