### PR TITLE
(Some) Accuracy for the right side shop panel 

### DIFF
--- a/src/engine/game/common/uibox.lua
+++ b/src/engine/game/common/uibox.lua
@@ -43,21 +43,24 @@ function UIBox:draw()
     local top_width   = self.top[1]:getWidth()
     local top_height  = self.top[1]:getHeight()
 
+    local width = math.floor(self.width)
+    local height = math.floor(self.height)
+
     local  r, g, b,a = self:getDrawColor()
     local fr,fg,fb   = unpack(self.fill_color)
     Draw.setColor(fr,fg,fb,a)
-    love.graphics.rectangle("fill", 0, 0, self.width, self.height)
+    love.graphics.rectangle("fill", 0, 0, width, height)
 
     Draw.setColor(r, g, b, a)
 
-    Draw.draw(self.left[math.floor(self.left_frame)], 0, 0, 0, 2, self.height / left_height, left_width, 0)
-    Draw.draw(self.left[math.floor(self.left_frame)], self.width, 0, math.pi, 2, self.height / left_height, left_width, left_height)
+    Draw.draw(self.left[math.floor(self.left_frame)], 0, 0, 0, 2, math.floor(height / left_height), left_width, 0)
+    Draw.draw(self.left[math.floor(self.left_frame)], width, 0, math.pi, 2, math.floor(height / left_height), left_width, left_height)
 
-    Draw.draw(self.top[math.floor(self.top_frame)], 0, 0, 0, self.width / top_width, 2, 0, top_height)
-    Draw.draw(self.top[math.floor(self.top_frame)], 0, self.height, math.pi, self.width / top_width, 2, top_width, top_height)
+    Draw.draw(self.top[math.floor(self.top_frame)], 0, 0, 0, math.floor(width / top_width), 2, 0, top_height)
+    Draw.draw(self.top[math.floor(self.top_frame)], 0, height, math.pi, math.floor(width / top_width), 2, top_width, top_height)
 
     for i = 1, 4 do
-        local cx, cy = self.corners[i][1] * self.width, self.corners[i][2] * self.height
+        local cx, cy = self.corners[i][1] * width, self.corners[i][2] * height
         local sprite = self.corner[math.floor(self.corner_frame)]
         local width  = 2 * ((self.corners[i][1] * 2) - 1) * -1
         local height = 2 * ((self.corners[i][2] * 2) - 1) * -1

--- a/src/engine/game/shop.lua
+++ b/src/engine/game/shop.lua
@@ -74,6 +74,8 @@
 --- The keys `map` (target map name), `x` and `y` OR `marker` (target position in map), `facing`, (player facing direction in map), `menu` (return to main menu) can be defined for this table.
 ---@field leave_options             { x: number, y: number, map: string, marker: string, facing: "up"|"right"|"down"|"left", menu: boolean }
 ---
+---@field expand_box                boolean     Whether the right side `info_box` should be expanded.
+---
 local Shop, super = Class(Object, "shop")
 
 ---@alias shopstate
@@ -229,11 +231,7 @@ function Shop:init()
 
     self.fade_alpha = 0
     self.fading_out = false
-    self.box_ease_timer = 0
-    self.box_ease_beginning = -8
-    self.box_ease_top = 220 - 48
-    self.box_ease_method = "outExpo"
-    self.box_ease_multiplier = 1
+    self.expand_box = false
 
     self.hide_price = false
 
@@ -458,15 +456,11 @@ function Shop:onStateChange(old,new)
         self.right_box.visible = true
         self.info_box.visible = true
         self.info_box.height = -8
-        self.box_ease_timer = 0
-        self.box_ease_beginning = -8
         if #self.items > 0 then
-            self.box_ease_top = 220 - 48
+            self.expand_box = true
         else
-            self.box_ease_top = -8
+            self.expand_box = false
         end
-        self.box_ease_method = "outExpo"
-        self.box_ease_multiplier = 1
         self.current_selecting = 1
     elseif new == "SELLMENU" then
         self:setDialogueText("")
@@ -709,10 +703,33 @@ function Shop:update()
 
     super.update(self)
 
-    self.box_ease_timer = math.min(1, self.box_ease_timer + (DT * self.box_ease_multiplier))
-
     if self.state == "BUYMENU" then
-        self.info_box.height = Utils.ease(self.box_ease_beginning, self.box_ease_top, self.box_ease_timer, self.box_ease_method)
+        -- Deltarune constricts the shopbox height (minimenuy) from 200 (bottom/smallest) to 20 (top/tallest)
+        -- Kristal UIBoxes work differently, so our new constraints are height from -8 (smallest) to 172 (tallest)
+        if self.expand_box then
+            if self.info_box.height >= 180 - 8 then
+                self.info_box.height = 180 - 8
+            end
+            if self.info_box.height < 180 - 8 then
+                self.info_box.height = self.info_box.height + 5 * DTMULT
+            end
+            if self.info_box.height < 150 - 8 then
+                self.info_box.height = self.info_box.height + 5 * DTMULT
+            end
+            if self.info_box.height < 100 - 8 then
+                self.info_box.height = self.info_box.height + 8 * DTMULT
+            end
+            if self.info_box.height < 50 - 8 then
+                self.info_box.height = self.info_box.height + 10 * DTMULT
+            end
+        else
+            if self.info_box.height > -8 then
+                self.info_box.height = self.info_box.height - 40 * DTMULT
+            end
+            if self.info_box.height <= -8 then
+                self.info_box.height = -8
+            end
+        end
 
         if self.shopkeeper.slide then
             local target_x = SCREEN_WIDTH/2 - 80
@@ -825,10 +842,10 @@ function Shop:draw()
             local current_item = self.items[self.current_selecting]
             local box_left, box_top = self.info_box:getBorder()
 
-            local left = self.info_box.x - self.info_box.width - (box_left / 2) * 1.5
-            local top = self.info_box.y - self.info_box.height - (box_top / 2) * 1.5
-            local width = self.info_box.width + box_left * 1.5
-            local height = self.info_box.height + box_top * 1.5
+            local left = self.info_box.x - math.floor(self.info_box.width) - (box_left / 2) * 1.5
+            local top = self.info_box.y - math.floor(self.info_box.height) - (box_top / 2) * 1.5
+            local width = math.floor(self.info_box.width) + box_left * 1.5
+            local height = math.floor(self.info_box.height) + box_top * 1.5
 
             Draw.pushScissor()
             Draw.scissor(left, top, width, height)
@@ -1141,17 +1158,9 @@ function Shop:onKeyPressed(key, is_repeat)
             end
             if Input.is("up", key) or Input.is("down", key) then
                 if self.current_selecting >= #self.items + 1 then
-                    self.box_ease_timer = 0
-                    self.box_ease_beginning = self.info_box.height
-                    self.box_ease_top = -8
-                    self.box_ease_method = "linear"
-                    self.box_ease_multiplier = 8
+                    self.expand_box = false
                 elseif (old_selecting >= #self.items + 1) and (self.current_selecting <= #self.items) then
-                    self.box_ease_timer = 0
-                    self.box_ease_beginning = self.info_box.height
-                    self.box_ease_top = 220 - 48
-                    self.box_ease_method = "outExpo"
-                    self.box_ease_multiplier = 1
+                    self.expand_box = true
                 end
             end
         end


### PR DESCRIPTION
This PR changes the shopbox panel on the rightside to use the deltarune formula for expanding/shrinking (now toggled with the `Shop.expand_box` variable)
Additionally, heights and widths used in calculations for the shopbox and UIBox are floored before being passed into draw to negate the jittering effect that fractional parts could cause -- only height flooring should have been needed to fix this specific case, but i went through the widths as well, because it might as well be future proofed now incase a mysterious side-expanding panel appears or anyone mods that in themselves and encounters this (and, i've not observed any side effects from changing this when checking different UIBoxes in the engine from before and after this change, just in case it could have had unintended consequences)