### PR TITLE
Added EnemyBattler.getCheckText()

### DIFF
--- a/mods/_testmod/scripts/battle/enemies/virovirokun.lua
+++ b/mods/_testmod/scripts/battle/enemies/virovirokun.lua
@@ -12,6 +12,8 @@ function Virovirokun:init()
     self.asleep = false
     self.become_red = false
 
+    self.nb_checks = 0
+
     self:registerAct("Tell Story", "", {"ralsei"})
     self:registerAct("Red", "", {"susie"})
     self:registerAct("", "", nil, nil, nil, {"ui/battle/msg/dumbass"})
@@ -34,6 +36,39 @@ function Virovirokun:getSpareText(battler, success)
         result[1] = "* " .. battler.chara:getName() .. " spared " .. self.name .. "!\n* But its name wasn't [color:green]GREEN[color:reset]..."
     end
     return result
+end
+
+function Virovirokun:onCheck()
+    self.nb_checks = self.nb_checks + 1
+end
+
+function Virovirokun:getCheckText(battler)
+    local text = super.getCheckText(self, battler)
+    if type(text) ~= "table" then
+        text = {text}
+    end
+
+    if #Game.battle:getActiveEnemies() > 100 then
+        return "* A LOT OF ENEMIES. YOU'RE GONNA DIE."
+    end
+
+    if self.nb_checks > 1 then
+        table.insert(text, "* "..battler.chara:getName().." can't get more info on the enemy!")
+    end
+
+    if self.nb_checks == 3 and #Game.battle.party >= 2 then
+        table.insert(text, "* "..Game.battle.party[2].chara:getName().." tells you to stop checking.")
+    elseif self.nb_checks == 4 and #Game.battle.party >= 3 then
+        table.insert(text, "* "..Game.battle.party[3].chara:getName().." begs you to stop checking!")
+    elseif self.nb_checks > 4 and self.nb_checks < 9 then
+        table.insert(text, "* What are you even doing?")
+    elseif self.nb_checks == 9 then
+        table.insert(text, "* [color:red]You feel like checking further is a bad idea[color:reset]...")
+    elseif self.nb_checks == 10 then
+        battler:hurt(999, nil, nil, {swoon=true})
+        return "* Ok you're getting annoying."
+    end
+    return text
 end
 
 function Virovirokun:mercyFlash(color)

--- a/src/engine/game/battle/enemybattler.lua
+++ b/src/engine/game/battle/enemybattler.lua
@@ -670,6 +670,25 @@ end
 ---@param battler PartyBattler
 function EnemyBattler:onCheck(battler) end
 
+--- *(Override)* Gets the text used by the Check act.
+--- *By default, returns the name of the enemy in all caps and then the value defined in EnemyBattler.check*
+---@param battler PartyBattler
+function EnemyBattler:getCheckText(battler)
+    if type(self.check) == "table" then
+        local tbl = {}
+        for i,check in ipairs(self.check) do
+            if i == 1 then
+                table.insert(tbl, "* " .. string.upper(self.name) .. " - " .. check)
+            else
+                table.insert(tbl, "* " .. check)
+            end
+        end
+        return tbl
+    else
+        return "* " .. string.upper(self.name) .. " - " .. self.check
+    end
+end
+
 --- *(Override)* Called when an ACT on this enemy starts \
 --- *By default, sets the sprties of all battlers involved in the act to `"battle/act"`
 ---@param battler PartyBattler  The battler using this act - if it is a multi-act, this only specifies the one who used the command
@@ -693,19 +712,7 @@ end
 function EnemyBattler:onAct(battler, name)
     if name == "Check" then
         self:onCheck(battler)
-        if type(self.check) == "table" then
-            local tbl = {}
-            for i,check in ipairs(self.check) do
-                if i == 1 then
-                    table.insert(tbl, "* " .. string.upper(self.name) .. " - " .. check)
-                else
-                    table.insert(tbl, "* " .. check)
-                end
-            end
-            return tbl
-        else
-            return "* " .. string.upper(self.name) .. " - " .. self.check
-        end
+        return self:getCheckText(battler)
     end
 end
 


### PR DESCRIPTION
This PR basically moves the code that sets up the Check text from `onAct` to its own function called `getCheckText()`

`getCheckText()` has two arguments:
- `battler`: the PartyMember that started the act, like onAct has.
- `separate`: Optional. If true, it will both return "* NAME - " and self.check separated instead of combining them together like it does usually.

May sound a bit overcomplicated? But this is basically what I suggested a while back on the server.

Also added an use case in the example mod as I believe learning there's a function that can override the check text is a good thing for new Kristal users.
There's also a use case in the _testmod for fun.

What about `onCheck()`? It's still here. _testmod now has a use case for it. You can easily see how it could be moved into `getCheckText()` but it doesn't feel right to me... So I guess it's still here for organization's sake?
If asked, I can just remove it altogether.