### PR TITLE
Fixed issues with the dark transition

### DIFF
--- a/src/engine/game/darktransition/darktransition.lua
+++ b/src/engine/game/darktransition/darktransition.lua
@@ -493,8 +493,10 @@ function DarkTransition:draw()
             self.timer = self.timer + 1 * DTMULT
         end
         self.sprite_index = ((self.timer / 36) * 5)
-        for _, data in ipairs(self.character_data) do
-            data.x = data.x_current + (math.sin(math.rad((self.timer * 2.5))) * self.radius) * data.movement
+        if #self.character_data > 1 then
+            for _, data in ipairs(self.character_data) do
+                data.x = data.x_current + (math.sin(math.rad((self.timer * 2.5))) * self.radius) * data.movement
+            end
         end
 
         if (self.timer >= 35) then
@@ -547,7 +549,6 @@ function DarkTransition:draw()
                 data.sprite_2:set("white")
                 data.sprite_3:set("dark")
                 data.top = data.sprite_3.texture:getHeight()
-                print(data.top)
 
                 data.sprite_1.cutout_bottom = 0
                 data.sprite_2.cutout_top = data.top
@@ -610,8 +611,8 @@ function DarkTransition:draw()
                     data.top = 0
                 end
 
-                if data.top >= 2 then
-                    local x = ((data.x + 3) + math.random((data.sprite_1.width - 6)))
+                if data.top >= 5 then
+                    local x = ((data.x + 6) + math.random((data.sprite_1.width)))
                     local y = (data.y + data.top)
 
                     for _ = 1, particle_amount do


### PR DESCRIPTION
1. Removed a leftover print() command.
2. Fixed particles accuracy.
3. When there's only 1 character, their position won't go to the right but stay in the middle.