### PR TITLE
Added missing reaction to Scarfmark weapon

### DIFF
--- a/data/items/weapons/scarfmark.lua
+++ b/data/items/weapons/scarfmark.lua
@@ -49,7 +49,10 @@ function item:init()
 
     -- Character reactions
     self.reactions = {
-        susie = "Heheh...",
+        susie = {
+            susie = "Heheh...",
+            ralsei = "Don't write that on it!!"
+        },
         ralsei = "I'll keep my place.",
         noelle = "Look, ribbon dancing!",
     }


### PR DESCRIPTION
It was missed most likely because all weapon reactions normally are located in "scr_weaponinfo", while this specific line from Ralsei was in "obj_darkcontroller"