### PR TITLE
Spell's numerical position in addSpell()

### DIFF
--- a/src/engine/game/common/data/partymember.lua
+++ b/src/engine/game/common/data/partymember.lua
@@ -537,11 +537,16 @@ end
 
 --- Adds a spell to this party member's set of available spells
 ---@param spell string|Spell
-function PartyMember:addSpell(spell)
+---@param pos number
+function PartyMember:addSpell(spell, pos)
     if type(spell) == "string" then
         spell = Registry.createSpell(spell)
     end
-    table.insert(self.spells, spell)
+    if pos then
+        table.insert(self.spells, pos, spell)
+    else
+        table.insert(self.spells, spell)
+    end
 end
 
 --- Removes a spell from this party member's available spells

--- a/src/engine/game/common/data/partymember.lua
+++ b/src/engine/game/common/data/partymember.lua
@@ -537,16 +537,21 @@ end
 
 --- Adds a spell to this party member's set of available spells
 ---@param spell string|Spell
----@param pos number
-function PartyMember:addSpell(spell, pos)
+function PartyMember:addSpell(spell)
     if type(spell) == "string" then
         spell = Registry.createSpell(spell)
     end
-    if pos then
-        table.insert(self.spells, pos, spell)
-    else
-        table.insert(self.spells, spell)
+    table.insert(self.spells, spell)
+end
+
+--- Inserts a spell to this party member's set of available spells at `index` position
+---@param index number
+---@param spell string|Spell
+function PartyMember:insertSpell(index, spell)
+    if type(spell) == "string" then
+        spell = Registry.createSpell(spell)
     end
+    table.insert(self.spells, index, spell)
 end
 
 --- Removes a spell from this party member's available spells


### PR DESCRIPTION
Adds a second argument to PartyMember:addSpell() which allows you to add the new spell in a certain position in the spell list instead of it always being the last one