### PR TITLE
Fixed border issue

### DIFF
--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -322,11 +322,10 @@ function Kristal.drawBorders()
             love.graphics.scale(Kristal.getGameScale())
             Draw.setColor(1, 1, 1, dynamic and BORDER_ALPHA or 1)
             love.graphics.push("all")
+            local border_width, border_height = 1920 * BORDER_SCALE, 1080 * BORDER_SCALE
             love.graphics.translate(
-                ((love.graphics.getWidth() / Kristal.getGameScale())) / 2 +
-                (((love.graphics.getHeight() / Kristal.getGameScale()) / -2) * (16 / 9)),
-                ((love.graphics.getHeight() / Kristal.getGameScale()) / 2) +
-                ((love.graphics.getHeight() / Kristal.getGameScale()) / -2)
+                (love.graphics.getWidth() / Kristal.getGameScale() - border_width) / 2,
+                (love.graphics.getHeight() / Kristal.getGameScale() - border_height) / 2
             )
             if border_texture then
                 Draw.draw(border_texture, 0, 0, 0, BORDER_SCALE)


### PR DESCRIPTION
This PR fixes an issue with borders being positioned improperly on certain devices with fullscreen enabled.
For borders with the expected 1920x1080 size, it should now be drawn accurately.

- [ ] This PR includes a DELTARUNE reimplementation or accuracy change
- [ ] I have referenced appropriate parts of DELTARUNE for this. The following code items were referenced for accuracy: `...`
- [x] I am a repeat contributor, or have added myself to the GitHub Contibutors in `src/engine/menu/mainmenucredits.lua`
